### PR TITLE
Fix the Skia generation

### DIFF
--- a/tokens/transformation/skia/index.js
+++ b/tokens/transformation/skia/index.js
@@ -22,8 +22,8 @@ const filteredTokens = (dictionary, filterFn) => {
     // convert to chromium's pascalCase convention
     const name = 'k' + tokens.name.split('-')
       .map((s) => s.charAt(0).toUpperCase() + s.substring(1)).join('')
-      .replace('LightMode', '')
-      .replace('DarkMode', '')
+      .replace('Light', '')
+      .replace('Dark', '')
     return { ...tokens, name, value }
   })
 
@@ -44,9 +44,10 @@ StyleDictionary.registerFormat({
     );
     
     const groupedTokens = {
-      // if you export the prefixes use token.path[0] instead of [1]
-      light: filteredTokens(dictionary, (token) => token.path[2]?.toLowerCase() === 'light-mode'),
-      dark: filteredTokens(dictionary, (token) => token.path[2]?.toLowerCase() === 'dark-mode'),
+      // Note: Here we check includes because the light/dark part of the token
+      // could be 2nd (for normal colors) or 3rd (for legacy colors).
+      light: filteredTokens(dictionary, (token) => token.path.includes('light')),
+      dark: filteredTokens(dictionary, (token) => token.path.includes('dark')),
       rest: filteredTokens(dictionary)
     }
 

--- a/tokens/transformation/skia/templates/colors.h.template
+++ b/tokens/transformation/skia/templates/colors.h.template
@@ -6,13 +6,13 @@
 #include "third_party/skia/include/core/SkColor.h"
 
 namespace leo::light {
-  <%= groupedTokens.light.allTokens.map(prop => {
-    return `constexpr SkColor ${prop.name} = SkColorSetRGB(${prop.value})`;
-  }).join(';\n') %>
-} // namespace leo
+<%= groupedTokens.light.allTokens.map(prop => {
+  return `constexpr SkColor ${prop.name} = SkColorSetRGB(${prop.value})`;
+}).map(s => `${s};`).join('\n') %>
+} // namespace leo::light
 
 namespace leo::dark {
-  <%= groupedTokens.dark.allTokens.map(prop => {
-    return `constexpr SkColor ${prop.name} = SkColorSetRGB(${prop.value})`;
-  }).join(';\n') %>
-} // namespace leo
+<%= groupedTokens.dark.allTokens.map(prop => {
+  return `constexpr SkColor ${prop.name} = SkColorSetRGB(${prop.value})`;
+}).map(s => `${s};`).join('\n') %>
+} // namespace leo::dark


### PR DESCRIPTION
The Skia generation was broken (the output file was empty). I think this happened when we added support for Legacy colors and changed `DarkMode`/`LightMode` to `Dark`/`Light`.

(also adds a trailing `;` & fixes the namespaces).

<details>
<summary>Example Output</summary>

```cpp
// Copyright (c) 2022 The Brave Authors. All rights reserved.
// This Source Code Form is subject to the terms of the Mozilla Public
// License, v. 2.0. If a copy of the MPL was not distributed with this file,
// you can obtain one at http://mozilla.org/MPL/2.0/.

#include "third_party/skia/include/core/SkColor.h"

namespace leo::light {
constexpr SkColor kColorTextPrimary = SkColorSetRGB(0x1D,0x1F,0x25);
constexpr SkColor kColorTextSecondary = SkColorSetRGB(0x6B,0x70,0x84);
constexpr SkColor kColorTextInteractive = SkColorSetRGB(0x20,0x4A,0xE3);
constexpr SkColor kColorTextDisabled = SkColorSetRGB(0x1D,0x1F,0x25);
constexpr SkColor kColorIconDefault = SkColorSetRGB(0x6B,0x70,0x84);
constexpr SkColor kColorIconInteractive = SkColorSetRGB(0x41,0x65,0xE9);
constexpr SkColor kColorIconDisabled = SkColorSetRGB(0x6B,0x70,0x84);
constexpr SkColor kColorInteractionButtonPrimaryBackground = SkColorSetRGB(0x20,0x4A,0xE3);
constexpr SkColor kColorPageBackground = SkColorSetRGB(0xF4,0xF6,0xF8);
constexpr SkColor kColorContainerBackground = SkColorSetRGB(0xFF,0xFF,0xFF);
constexpr SkColor kColorContainerHighlight = SkColorSetRGB(0xF4,0xF6,0xF8);
constexpr SkColor kColorContainerInteractiveBackground = SkColorSetRGB(0xF3,0xF5,0xFE);
constexpr SkColor kColorContainerDisabled = SkColorSetRGB(0xAC,0xAF,0xBB);
constexpr SkColor kColorModalScreenBackground = SkColorSetRGB(0x12,0x13,0x16);
constexpr SkColor kColorDividerSubtle = SkColorSetRGB(0xE2,0xE3,0xE7);
constexpr SkColor kColorDividerStrong = SkColorSetRGB(0xAC,0xAF,0xBB);
constexpr SkColor kColorSystemfeedbackInfoBackground = SkColorSetRGB(0xE4,0xF0,0xF9);
constexpr SkColor kColorSystemfeedbackInfoIcon = SkColorSetRGB(0x0F,0x75,0xC9);
constexpr SkColor kColorSystemfeedbackErrorBackground = SkColorSetRGB(0xFC,0xEA,0xED);
constexpr SkColor kColorSystemfeedbackErrorIcon = SkColorSetRGB(0xDC,0x1D,0x3C);
constexpr SkColor kColorSystemfeedbackWarningBackground = SkColorSetRGB(0xFF,0xF4,0xD8);
constexpr SkColor kColorSystemfeedbackWarningIcon = SkColorSetRGB(0x92,0x6A,0x00);
constexpr SkColor kColorSystemfeedbackSuccessBackground = SkColorSetRGB(0xDB,0xF5,0xDF);
constexpr SkColor kColorSystemfeedbackSuccessIcon = SkColorSetRGB(0x31,0x80,0x3E);
constexpr SkColor kColorGray10 = SkColorSetRGB(0xF4,0xF6,0xF8);
constexpr SkColor kColorGray20 = SkColorSetRGB(0xE2,0xE3,0xE7);
constexpr SkColor kColorGray30 = SkColorSetRGB(0xAC,0xAF,0xBB);
constexpr SkColor kColorGray40 = SkColorSetRGB(0x6B,0x70,0x84);
constexpr SkColor kColorGray50 = SkColorSetRGB(0x58,0x5C,0x6D);
constexpr SkColor kColorGray60 = SkColorSetRGB(0x42,0x45,0x52);
constexpr SkColor kColorGray70 = SkColorSetRGB(0x1D,0x1F,0x25);
constexpr SkColor kColorPrimary10 = SkColorSetRGB(0xF3,0xF5,0xFE);
constexpr SkColor kColorPrimary20 = SkColorSetRGB(0xDD,0xE4,0xFB);
constexpr SkColor kColorPrimary30 = SkColorSetRGB(0x99,0xAD,0xF3);
constexpr SkColor kColorPrimary40 = SkColorSetRGB(0x41,0x65,0xE9);
constexpr SkColor kColorPrimary50 = SkColorSetRGB(0x20,0x4A,0xE3);
constexpr SkColor kColorPrimary60 = SkColorSetRGB(0x18,0x38,0xAC);
constexpr SkColor kColorPrimary70 = SkColorSetRGB(0x0B,0x1A,0x4F);
constexpr SkColor kColorSecondary10 = SkColorSetRGB(0xFD,0xF4,0xF2);
constexpr SkColor kColorSecondary20 = SkColorSetRGB(0xFE,0xDE,0xD6);
constexpr SkColor kColorSecondary30 = SkColorSetRGB(0xFC,0x93,0x78);
constexpr SkColor kColorSecondary40 = SkColorSetRGB(0xFE,0x59,0x07);
constexpr SkColor kColorSecondary50 = SkColorSetRGB(0xB2,0x26,0x03);
constexpr SkColor kColorSecondary60 = SkColorSetRGB(0x86,0x1D,0x03);
constexpr SkColor kColorSecondary70 = SkColorSetRGB(0x3F,0x0E,0x01);
constexpr SkColor kColorRed10 = SkColorSetRGB(0xFD,0xF3,0xF5);
constexpr SkColor kColorRed20 = SkColorSetRGB(0xFB,0xDE,0xE3);
constexpr SkColor kColorRed30 = SkColorSetRGB(0xF1,0x95,0xA4);
constexpr SkColor kColorRed40 = SkColorSetRGB(0xDC,0x1D,0x3C);
constexpr SkColor kColorRed50 = SkColorSetRGB(0xB8,0x18,0x32);
constexpr SkColor kColorRed60 = SkColorSetRGB(0x8A,0x12,0x26);
constexpr SkColor kColorRed70 = SkColorSetRGB(0x41,0x09,0x12);
constexpr SkColor kColorYellow10 = SkColorSetRGB(0xFF,0xF4,0xD8);
constexpr SkColor kColorYellow20 = SkColorSetRGB(0xFF,0xE1,0x93);
constexpr SkColor kColorYellow30 = SkColorSetRGB(0xE2,0xA5,0x00);
constexpr SkColor kColorYellow40 = SkColorSetRGB(0x92,0x6A,0x00);
constexpr SkColor kColorYellow50 = SkColorSetRGB(0x78,0x57,0x00);
constexpr SkColor kColorYellow60 = SkColorSetRGB(0x5A,0x41,0x00);
constexpr SkColor kColorYellow70 = SkColorSetRGB(0x28,0x1D,0x00);
constexpr SkColor kColorGreen10 = SkColorSetRGB(0xE8,0xF9,0xEB);
constexpr SkColor kColorGreen20 = SkColorSetRGB(0xC2,0xEE,0xC9);
constexpr SkColor kColorGreen30 = SkColorSetRGB(0x4D,0xC6,0x61);
constexpr SkColor kColorGreen40 = SkColorSetRGB(0x31,0x80,0x3E);
constexpr SkColor kColorGreen50 = SkColorSetRGB(0x29,0x69,0x33);
constexpr SkColor kColorGreen60 = SkColorSetRGB(0x1F,0x4F,0x27);
constexpr SkColor kColorGreen70 = SkColorSetRGB(0x0E,0x23,0x11);
constexpr SkColor kColorTeal10 = SkColorSetRGB(0xEF,0xF7,0xF8);
constexpr SkColor kColorTeal20 = SkColorSetRGB(0xD1,0xE8,0xEB);
constexpr SkColor kColorTeal30 = SkColorSetRGB(0x76,0xBA,0xC2);
constexpr SkColor kColorTeal40 = SkColorSetRGB(0x00,0x7C,0x8A);
constexpr SkColor kColorTeal50 = SkColorSetRGB(0x00,0x67,0x72);
constexpr SkColor kColorTeal60 = SkColorSetRGB(0x00,0x4D,0x56);
constexpr SkColor kColorTeal70 = SkColorSetRGB(0x00,0x23,0x27);
constexpr SkColor kColorBlue10 = SkColorSetRGB(0xF0,0xF7,0xFC);
constexpr SkColor kColorBlue20 = SkColorSetRGB(0xD0,0xE8,0xFC);
constexpr SkColor kColorBlue30 = SkColorSetRGB(0x6A,0xB6,0xF4);
constexpr SkColor kColorBlue40 = SkColorSetRGB(0x0F,0x75,0xC9);
constexpr SkColor kColorBlue50 = SkColorSetRGB(0x0C,0x5F,0xA3);
constexpr SkColor kColorBlue60 = SkColorSetRGB(0x09,0x47,0x7A);
constexpr SkColor kColorBlue70 = SkColorSetRGB(0x04,0x20,0x38);
constexpr SkColor kColorPurple10 = SkColorSetRGB(0xF5,0xF6,0xFC);
constexpr SkColor kColorPurple20 = SkColorSetRGB(0xE1,0xE3,0xF7);
constexpr SkColor kColorPurple30 = SkColorSetRGB(0xA6,0xAB,0xE8);
constexpr SkColor kColorPurple40 = SkColorSetRGB(0x5D,0x65,0xD3);
constexpr SkColor kColorPurple50 = SkColorSetRGB(0x4C,0x53,0xAD);
constexpr SkColor kColorPurple60 = SkColorSetRGB(0x39,0x3E,0x82);
constexpr SkColor kColorPurple70 = SkColorSetRGB(0x1A,0x1C,0x3B);
constexpr SkColor kColorPink10 = SkColorSetRGB(0xFD,0xF3,0xF8);
constexpr SkColor kColorPink20 = SkColorSetRGB(0xFA,0xDB,0xEC);
constexpr SkColor kColorPink30 = SkColorSetRGB(0xF0,0x92,0xC5);
constexpr SkColor kColorPink40 = SkColorSetRGB(0xD4,0x1C,0x80);
constexpr SkColor kColorPink50 = SkColorSetRGB(0xAF,0x17,0x69);
constexpr SkColor kColorPink60 = SkColorSetRGB(0x85,0x11,0x50);
constexpr SkColor kColorPink70 = SkColorSetRGB(0x3F,0x08,0x26);
constexpr SkColor kColorPrivateWindow10 = SkColorSetRGB(0xF5,0xF4,0xFA);
constexpr SkColor kColorPrivateWindow20 = SkColorSetRGB(0xE5,0xE2,0xF0);
constexpr SkColor kColorPrivateWindow30 = SkColorSetRGB(0xB3,0xAA,0xD3);
constexpr SkColor kColorPrivateWindow40 = SkColorSetRGB(0x75,0x66,0xB0);
constexpr SkColor kColorPrivateWindow50 = SkColorSetRGB(0x61,0x4F,0xA4);
constexpr SkColor kColorPrivateWindow60 = SkColorSetRGB(0x48,0x33,0x96);
constexpr SkColor kColorPrivateWindow70 = SkColorSetRGB(0x1E,0x0D,0x5E);
constexpr SkColor kColorTorWindow10 = SkColorSetRGB(0xF8,0xF5,0xFA);
constexpr SkColor kColorTorWindow20 = SkColorSetRGB(0xEB,0xE1,0xF0);
constexpr SkColor kColorTorWindow30 = SkColorSetRGB(0xC2,0xA5,0xD1);
constexpr SkColor kColorTorWindow40 = SkColorSetRGB(0x91,0x5E,0xAD);
constexpr SkColor kColorTorWindow50 = SkColorSetRGB(0x78,0x4A,0x91);
constexpr SkColor kColorTorWindow60 = SkColorSetRGB(0x5A,0x37,0x6C);
constexpr SkColor kColorTorWindow70 = SkColorSetRGB(0x27,0x1A,0x2F);
constexpr SkColor kColorLegacyBackground1 = SkColorSetRGB(0xFF,0xFF,0xFF);
constexpr SkColor kColorLegacyBackground2 = SkColorSetRGB(0xF8,0xF9,0xFA);
constexpr SkColor kColorLegacyText1 = SkColorSetRGB(0x21,0x25,0x29);
constexpr SkColor kColorLegacyText2 = SkColorSetRGB(0x49,0x50,0x57);
constexpr SkColor kColorLegacyText3 = SkColorSetRGB(0x86,0x8E,0x96);
constexpr SkColor kColorLegacyInteractive1 = SkColorSetRGB(0xEA,0x3A,0x0D);
constexpr SkColor kColorLegacyInteractive2 = SkColorSetRGB(0xFB,0x54,0x2B);
constexpr SkColor kColorLegacyInteractive3 = SkColorSetRGB(0xFF,0x76,0x54);
constexpr SkColor kColorLegacyInteractive4 = SkColorSetRGB(0x35,0x3D,0xAB);
constexpr SkColor kColorLegacyInteractive5 = SkColorSetRGB(0x4C,0x54,0xD2);
constexpr SkColor kColorLegacyInteractive6 = SkColorSetRGB(0x73,0x7A,0xDE);
constexpr SkColor kColorLegacyInteractive7 = SkColorSetRGB(0x21,0x25,0x29);
constexpr SkColor kColorLegacyInteractive8 = SkColorSetRGB(0xAE,0xB1,0xC2);
constexpr SkColor kColorLegacyDisabled = SkColorSetRGB(0xDA,0xDC,0xE8);
constexpr SkColor kColorLegacyFocusBorder = SkColorSetRGB(0xA0,0xA5,0xEB);
constexpr SkColor kColorLegacyDivider1 = SkColorSetRGB(0xE9,0xE9,0xF4);
} // namespace leo::light

namespace leo::dark {
constexpr SkColor kColorTextPrimary = SkColorSetRGB(0xEC,0xEF,0xF2);
constexpr SkColor kColorTextSecondary = SkColorSetRGB(0x8C,0x90,0xA1);
constexpr SkColor kColorTextInteractive = SkColorSetRGB(0x99,0xAD,0xF3);
constexpr SkColor kColorTextDisabled = SkColorSetRGB(0xEC,0xEF,0xF2);
constexpr SkColor kColorIconDefault = SkColorSetRGB(0x8C,0x90,0xA1);
constexpr SkColor kColorIconInteractive = SkColorSetRGB(0x70,0x8B,0xEE);
constexpr SkColor kColorIconDisabled = SkColorSetRGB(0x8C,0x90,0xA1);
constexpr SkColor kColorInteractionButtonPrimaryBackground = SkColorSetRGB(0x20,0x4A,0xE3);
constexpr SkColor kColorPageBackground = SkColorSetRGB(0x12,0x13,0x16);
constexpr SkColor kColorContainerBackground = SkColorSetRGB(0x1D,0x1F,0x25);
constexpr SkColor kColorContainerHighlight = SkColorSetRGB(0x12,0x13,0x16);
constexpr SkColor kColorContainerInteractiveBackground = SkColorSetRGB(0x07,0x10,0x32);
constexpr SkColor kColorContainerDisabled = SkColorSetRGB(0x58,0x5C,0x6D);
constexpr SkColor kColorModalScreenBackground = SkColorSetRGB(0x12,0x13,0x16);
constexpr SkColor kColorDividerSubtle = SkColorSetRGB(0x2E,0x30,0x39);
constexpr SkColor kColorDividerStrong = SkColorSetRGB(0x58,0x5C,0x6D);
constexpr SkColor kColorSystemfeedbackInfoBackground = SkColorSetRGB(0x04,0x20,0x38);
constexpr SkColor kColorSystemfeedbackInfoIcon = SkColorSetRGB(0x27,0x95,0xEF);
constexpr SkColor kColorSystemfeedbackErrorBackground = SkColorSetRGB(0x41,0x09,0x12);
constexpr SkColor kColorSystemfeedbackErrorIcon = SkColorSetRGB(0xEB,0x63,0x7A);
constexpr SkColor kColorSystemfeedbackWarningBackground = SkColorSetRGB(0x19,0x12,0x00);
constexpr SkColor kColorSystemfeedbackWarningIcon = SkColorSetRGB(0xBB,0x88,0x00);
constexpr SkColor kColorSystemfeedbackSuccessBackground = SkColorSetRGB(0x0E,0x23,0x11);
constexpr SkColor kColorSystemfeedbackSuccessIcon = SkColorSetRGB(0x3F,0xA4,0x50);
constexpr SkColor kColorGray10 = SkColorSetRGB(0x12,0x13,0x16);
constexpr SkColor kColorGray20 = SkColorSetRGB(0x2E,0x30,0x39);
constexpr SkColor kColorGray30 = SkColorSetRGB(0x58,0x5C,0x6D);
constexpr SkColor kColorGray40 = SkColorSetRGB(0x8C,0x90,0xA1);
constexpr SkColor kColorGray50 = SkColorSetRGB(0xAC,0xAF,0xBB);
constexpr SkColor kColorGray60 = SkColorSetRGB(0xC6,0xC8,0xD0);
constexpr SkColor kColorGray70 = SkColorSetRGB(0xEC,0xEF,0xF2);
constexpr SkColor kColorPrimary10 = SkColorSetRGB(0x07,0x10,0x32);
constexpr SkColor kColorPrimary20 = SkColorSetRGB(0x11,0x27,0x79);
constexpr SkColor kColorPrimary30 = SkColorSetRGB(0x20,0x4A,0xE3);
constexpr SkColor kColorPrimary40 = SkColorSetRGB(0x70,0x8B,0xEE);
constexpr SkColor kColorPrimary50 = SkColorSetRGB(0x99,0xAD,0xF3);
constexpr SkColor kColorPrimary60 = SkColorSetRGB(0xBA,0xC7,0xF7);
constexpr SkColor kColorPrimary70 = SkColorSetRGB(0xEC,0xEF,0xFD);
constexpr SkColor kColorSecondary10 = SkColorSetRGB(0x28,0x09,0x01);
constexpr SkColor kColorSecondary20 = SkColorSetRGB(0x5F,0x14,0x02);
constexpr SkColor kColorSecondary30 = SkColorSetRGB(0xB2,0x26,0x03);
constexpr SkColor kColorSecondary40 = SkColorSetRGB(0xFB,0x59,0x30);
constexpr SkColor kColorSecondary50 = SkColorSetRGB(0xFC,0x93,0x78);
constexpr SkColor kColorSecondary60 = SkColorSetRGB(0xFD,0xB7,0xA5);
constexpr SkColor kColorSecondary70 = SkColorSetRGB(0xFC,0xEC,0xE8);
constexpr SkColor kColorRed10 = SkColorSetRGB(0x2A,0x06,0x0B);
constexpr SkColor kColorRed20 = SkColorSetRGB(0x63,0x0D,0x1B);
constexpr SkColor kColorRed30 = SkColorSetRGB(0xB8,0x18,0x32);
constexpr SkColor kColorRed40 = SkColorSetRGB(0xEB,0x63,0x7A);
constexpr SkColor kColorRed50 = SkColorSetRGB(0xF1,0x95,0xA4);
constexpr SkColor kColorRed60 = SkColorSetRGB(0xF6,0xB8,0xC2);
constexpr SkColor kColorRed70 = SkColorSetRGB(0xFC,0xEA,0xED);
constexpr SkColor kColorYellow10 = SkColorSetRGB(0x19,0x12,0x00);
constexpr SkColor kColorYellow20 = SkColorSetRGB(0x3F,0x2E,0x00);
constexpr SkColor kColorYellow30 = SkColorSetRGB(0x78,0x57,0x00);
constexpr SkColor kColorYellow40 = SkColorSetRGB(0xBB,0x88,0x00);
constexpr SkColor kColorYellow50 = SkColorSetRGB(0xE2,0xA5,0x00);
constexpr SkColor kColorYellow60 = SkColorSetRGB(0xFE,0xBF,0x17);
constexpr SkColor kColorYellow70 = SkColorSetRGB(0xFF,0xEE,0xC1);
constexpr SkColor kColorGreen10 = SkColorSetRGB(0x08,0x16,0x0B);
constexpr SkColor kColorGreen20 = SkColorSetRGB(0x15,0x37,0x1B);
constexpr SkColor kColorGreen30 = SkColorSetRGB(0x29,0x69,0x33);
constexpr SkColor kColorGreen40 = SkColorSetRGB(0x3F,0xA4,0x50);
constexpr SkColor kColorGreen50 = SkColorSetRGB(0x4D,0xC6,0x61);
constexpr SkColor kColorGreen60 = SkColorSetRGB(0x81,0xDC,0x90);
constexpr SkColor kColorGreen70 = SkColorSetRGB(0xDB,0xF5,0xDF);
constexpr SkColor kColorTeal10 = SkColorSetRGB(0x00,0x16,0x19);
constexpr SkColor kColorTeal20 = SkColorSetRGB(0x00,0x36,0x3C);
constexpr SkColor kColorTeal30 = SkColorSetRGB(0x00,0x67,0x72);
constexpr SkColor kColorTeal40 = SkColorSetRGB(0x3D,0x9E,0xA8);
constexpr SkColor kColorTeal50 = SkColorSetRGB(0x76,0xBA,0xC2);
constexpr SkColor kColorTeal60 = SkColorSetRGB(0xA4,0xD1,0xD6);
constexpr SkColor kColorTeal70 = SkColorSetRGB(0xE3,0xF1,0xF2);
constexpr SkColor kColorBlue10 = SkColorSetRGB(0x02,0x15,0x23);
constexpr SkColor kColorBlue20 = SkColorSetRGB(0x06,0x32,0x56);
constexpr SkColor kColorBlue30 = SkColorSetRGB(0x0C,0x5F,0xA3);
constexpr SkColor kColorBlue40 = SkColorSetRGB(0x27,0x95,0xEF);
constexpr SkColor kColorBlue50 = SkColorSetRGB(0x6A,0xB6,0xF4);
constexpr SkColor kColorBlue60 = SkColorSetRGB(0x9B,0xCE,0xF8);
constexpr SkColor kColorBlue70 = SkColorSetRGB(0xE4,0xF0,0xF9);
constexpr SkColor kColorPurple10 = SkColorSetRGB(0x10,0x11,0x24);
constexpr SkColor kColorPurple20 = SkColorSetRGB(0x28,0x2C,0x5A);
constexpr SkColor kColorPurple30 = SkColorSetRGB(0x4C,0x53,0xAD);
constexpr SkColor kColorPurple40 = SkColorSetRGB(0x83,0x89,0xDF);
constexpr SkColor kColorPurple50 = SkColorSetRGB(0xA6,0xAB,0xE8);
constexpr SkColor kColorPurple60 = SkColorSetRGB(0xC3,0xC6,0xF0);
constexpr SkColor kColorPurple70 = SkColorSetRGB(0xED,0xEE,0xFA);
constexpr SkColor kColorPink10 = SkColorSetRGB(0x29,0x05,0x19);
constexpr SkColor kColorPink20 = SkColorSetRGB(0x5F,0x0C,0x39);
constexpr SkColor kColorPink30 = SkColorSetRGB(0xAF,0x17,0x69);
constexpr SkColor kColorPink40 = SkColorSetRGB(0xE8,0x5F,0xA9);
constexpr SkColor kColorPink50 = SkColorSetRGB(0xF0,0x92,0xC5);
constexpr SkColor kColorPink60 = SkColorSetRGB(0xF5,0xB6,0xD8);
constexpr SkColor kColorPink70 = SkColorSetRGB(0xFC,0xE9,0xF3);
constexpr SkColor kColorPrivateWindow10 = SkColorSetRGB(0x1E,0x0D,0x5E);
constexpr SkColor kColorPrivateWindow20 = SkColorSetRGB(0x48,0x33,0x96);
constexpr SkColor kColorPrivateWindow30 = SkColorSetRGB(0x61,0x4F,0xA4);
constexpr SkColor kColorPrivateWindow40 = SkColorSetRGB(0x75,0x66,0xB0);
constexpr SkColor kColorPrivateWindow50 = SkColorSetRGB(0xB3,0xAA,0xD3);
constexpr SkColor kColorPrivateWindow60 = SkColorSetRGB(0xE5,0xE2,0xF0);
constexpr SkColor kColorPrivateWindow70 = SkColorSetRGB(0xF5,0xF4,0xFA);
constexpr SkColor kColorTorWindow10 = SkColorSetRGB(0x18,0x10,0x1D);
constexpr SkColor kColorTorWindow20 = SkColorSetRGB(0x3F,0x27,0x4C);
constexpr SkColor kColorTorWindow30 = SkColorSetRGB(0x78,0x4A,0x91);
constexpr SkColor kColorTorWindow40 = SkColorSetRGB(0xA9,0x81,0xBF);
constexpr SkColor kColorTorWindow50 = SkColorSetRGB(0xC2,0xA5,0xD1);
constexpr SkColor kColorTorWindow60 = SkColorSetRGB(0xD5,0xC2,0xE0);
constexpr SkColor kColorTorWindow70 = SkColorSetRGB(0xF2,0xED,0xF5);
constexpr SkColor kColorLegacyBackground1 = SkColorSetRGB(0x1E,0x20,0x29);
constexpr SkColor kColorLegacyBackground2 = SkColorSetRGB(0x17,0x17,0x1F);
constexpr SkColor kColorLegacyText1 = SkColorSetRGB(0xF0,0xF2,0xFF);
constexpr SkColor kColorLegacyText2 = SkColorSetRGB(0xC2,0xC4,0xCF);
constexpr SkColor kColorLegacyText3 = SkColorSetRGB(0x84,0x88,0x9C);
constexpr SkColor kColorLegacyInteractive1 = SkColorSetRGB(0xEA,0x3A,0x0D);
constexpr SkColor kColorLegacyInteractive2 = SkColorSetRGB(0xFB,0x54,0x2B);
constexpr SkColor kColorLegacyInteractive3 = SkColorSetRGB(0xFF,0x76,0x54);
constexpr SkColor kColorLegacyInteractive4 = SkColorSetRGB(0x35,0x3D,0xAB);
constexpr SkColor kColorLegacyInteractive5 = SkColorSetRGB(0x4C,0x54,0xD2);
constexpr SkColor kColorLegacyInteractive6 = SkColorSetRGB(0x73,0x7A,0xDE);
constexpr SkColor kColorLegacyInteractive7 = SkColorSetRGB(0xF0,0xF2,0xFF);
constexpr SkColor kColorLegacyInteractive8 = SkColorSetRGB(0x5E,0x61,0x75);
constexpr SkColor kColorLegacyDisabled = SkColorSetRGB(0x34,0x3A,0x40);
constexpr SkColor kColorLegacyFocusBorder = SkColorSetRGB(0xA0,0xA5,0xEB);
constexpr SkColor kColorLegacyDivider1 = SkColorSetRGB(0x3B,0x3E,0x4F);
} // namespace leo::dark
```

</details>