### PR TITLE
moves svelte2tsx to prod dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,10 @@
     "@tsconfig/svelte": "3.0.0",
     "lodash.merge": "4.6.2",
     "style-dictionary": "3.7.1",
-    "svelte": "3.53.1",
     "svelte-check": "2.10.0",
     "svelte-preprocess": "4.10.7",
+    "svelte": "3.53.1",
+    "svelte2tsx": "0.5.21",
     "tailwindcss": "3.2.4",
     "ts-jest": "29.0.3",
     "tslib": "2.4.1"
@@ -38,8 +39,7 @@
     "sass": "1.56.1",
     "sass-loader": "13.2.0",
     "style-loader": "3.3.1",
-    "svelte-loader": "3.1.4",
-    "svelte2tsx": "0.5.21"
+    "svelte-loader": "3.1.4"
   },
   "peerDependencies": {
     "typescript": "4.9.3"


### PR DESCRIPTION
Installing in another project was returning an error due to a this package missing.
