### PR TITLE
Fix React bindings when we have generic arguments

### DIFF
--- a/examples/example-ui-react/src/App.tsx
+++ b/examples/example-ui-react/src/App.tsx
@@ -37,7 +37,7 @@ function App() {
         >
           {buttonText}
         </LeoButton>
-        <LeoButton href='#foo' onClick={() => {}}>Link button!</LeoButton>
+        <LeoButton href='#foo'>Link button!</LeoButton>
         <SvelteReactComponent
           button_text={'ATTRIBUTE TEXT FROM REACT' + (acted ? ':MODIFIED' : '')}
           onHello={handleSvelteComponentHello}

--- a/examples/example-ui-react/src/App.tsx
+++ b/examples/example-ui-react/src/App.tsx
@@ -30,10 +30,14 @@ function App() {
         <LeoButton
           kind='primary'
           size='large'
-          onClick={() => alert('clicked')}
+          onClick={() => {
+            location.hash = ''
+            alert('clicked!')
+          }}
         >
           {buttonText}
         </LeoButton>
+        <LeoButton href='#foo' onClick={() => {}}>Link button!</LeoButton>
         <SvelteReactComponent
           button_text={'ATTRIBUTE TEXT FROM REACT' + (acted ? ':MODIFIED' : '')}
           onHello={handleSvelteComponentHello}

--- a/scripts/gen-react-bindings.js
+++ b/scripts/gen-react-bindings.js
@@ -15,7 +15,7 @@ const getReactFileContents = (svelteFilePath) => {
     const fileNameWithoutExtension = fileName.substring(0, fileName.length - extension.length);
     const componentName = fileNameWithoutExtension[0].toUpperCase() + fileNameWithoutExtension.substring(1);
     const fileContents = `
-import SvelteToReact, { ReactProps } from '${svelteReactWrapperRelativePath}';
+import SvelteToReact, { type ReactProps } from '${svelteReactWrapperRelativePath}';
 import ${componentName} from './${fileName}';
 import type { ${componentName}Events, ${componentName}Props } from './${fileName}';
 

--- a/web-components/button/button.svelte
+++ b/web-components/button/button.svelte
@@ -47,7 +47,7 @@
   export let isDisabled: Disabled = undefined
   export let href: Href = undefined
 
-  const tag = href ? 'a' : 'button'
+  $: tag = href ? 'a' : 'button'
 
   const dispatch = createEventDispatcher()
 

--- a/web-components/button/button.svelte
+++ b/web-components/button/button.svelte
@@ -1,7 +1,8 @@
 <svelte:options tag="leo-button" />
 
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte';
+  import { createEventDispatcher } from 'svelte'
+  import type { SvelteHTMLElements } from 'svelte/elements'
   import type * as Props from './props'
 
   // This black magic comes from this thread:
@@ -17,51 +18,73 @@
   // 1) npm run gen-types
   // 2) Reload your VSCode Window (sometimes the Svelte Type Checker struggles).
   // 3) Make sure any script tags on your component have a `lang="ts"` attribute.
-  type Href = $$Generic<string | undefined>;
-  type Disabled = $$Generic<undefined extends Href ? boolean : undefined>;
-  type ExcludedProps = 'size' | 'href' | 'hreflang';
+  type Href = $$Generic<string | undefined>
+  type Disabled = $$Generic<undefined extends Href ? boolean : undefined>
+  type ExcludedProps = 'size' | 'href' | 'hreflang'
 
   interface CommonProps {
-    kind?: Props.ButtonKind;
-    size?: Props.ButtonSize;
-    isLoading?: boolean;
+    kind?: Props.ButtonKind
+    size?: Props.ButtonSize
+    isLoading?: boolean
   }
 
-  type ButtonProps = CommonProps & Omit<Partial<svelte.JSX.HTMLAttributes<HTMLElementTagNameMap['button']>>, ExcludedProps> & {
-    isDisabled?: Disabled;
-    href?: never;
-  }
+  type ButtonProps = CommonProps &
+    Omit<Partial<SvelteHTMLElements['button']>, ExcludedProps> & {
+      isDisabled?: Disabled
+      href?: never
+    }
 
-  type LinkProps = CommonProps & Omit<Partial<svelte.JSX.HTMLAttributes<HTMLElementTagNameMap['a']>>, ExcludedProps> & {
-    href: Href;
-  }
+  type LinkProps = CommonProps &
+    Omit<Partial<SvelteHTMLElements['a']>, ExcludedProps> & {
+      href: Href
+    }
 
-  type $$Props = (LinkProps | ButtonProps)
+  type $$Props = LinkProps | ButtonProps
 
-  export let kind: Props.ButtonKind = "primary"
-  export let size: Props.ButtonSize = "medium"
+  export let kind: Props.ButtonKind = 'primary'
+  export let size: Props.ButtonSize = 'medium'
   export let isLoading: boolean = false
-  export let isDisabled: Disabled = undefined;
-  export let href: Href = undefined;
+  export let isDisabled: Disabled = undefined
+  export let href: Href = undefined
 
-  const tag = href ? "a" : "button";
+  const tag = href ? 'a' : 'button'
 
-  const dispatch = createEventDispatcher();
+  const dispatch = createEventDispatcher()
 
   /**
    * Optional click handler
    */
   function onClick(event) {
-    dispatch('click', event);
+    dispatch('click', event)
   }
 </script>
+
+<svelte:element
+  this={tag}
+  href={href || undefined}
+  class="leoButton"
+  class:isPrimary={kind === 'primary'}
+  class:isSecondary={kind === 'secondary'}
+  class:isTertiary={kind === 'tertiary'}
+  class:isCTA={kind === 'CTA'}
+  class:isLarge={size === 'large'}
+  class:isMedium={size === 'medium'}
+  class:isSmall={size === 'small'}
+  class:isLoading
+  disabled={isDisabled || undefined}
+  on:click={onClick}
+  {...$$restProps}
+>
+  <slot>Leo Button</slot>
+</svelte:element>
 
 <style lang="scss">
   // Main styles and states
   .leoButton {
     // Gradients cannot have a transition, so we need to reset `transition`
     // to only apply to `box-shadow` and `border-color` in .isCTA
-    --default-transition: box-shadow 0.12s ease-in-out, color 0.12s ease-in-out, border-color 0.12s ease-in-out;
+    --default-transition: box-shadow 0.12s ease-in-out, color 0.12s ease-in-out,
+      border-color 0.12s ease-in-out;
     --box-shadow-hover: var(--effect-elevation-02);
     display: block;
     cursor: pointer;
@@ -190,22 +213,3 @@
     --color: white;
   }
 </style>
-
-<svelte:element
-  this={tag}
-  href={href || undefined}
-  class="leoButton"
-  class:isPrimary={kind === 'primary'}
-  class:isSecondary={kind === 'secondary'}
-  class:isTertiary={kind === 'tertiary'}
-  class:isCTA={kind === 'CTA'}
-  class:isLarge={size === 'large'}
-  class:isMedium={size === 'medium'}
-  class:isSmall={size === 'small'}
-  class:isLoading
-  disabled={isDisabled || undefined}
-  on:click={onClick}
-  {...$$restProps}
->
-  <slot>Leo Button</slot>
-</svelte:element>

--- a/web-components/svelte-react.ts
+++ b/web-components/svelte-react.ts
@@ -87,7 +87,7 @@ export default function SvelteWebComponentToReact<T extends Record<string, any>>
           watchers.forEach(([name, callback]) => {
             if (component.current) {
               const index = component.current.$$.props[name]
-              callback(component.current.$$.ctx[index])
+              callback((component.current.$$.ctx as any)[index])
             }
           })
           update.apply(null, updateArgs)

--- a/web-components/svelte-react.ts
+++ b/web-components/svelte-react.ts
@@ -22,7 +22,7 @@ const watchRegex = /watch([A-Z]{1,}[a-zA-Z]*)/
 export type SvelteProps<T> = T extends SvelteComponentTyped<infer Props, any, any> ? Props : {}
 export type SvelteEvents<T> = T extends SvelteComponentTyped<any, infer Events, any> ? Events : {}
 export type ReactProps<Props, Events> = Props & {
-  [P in keyof Events as `on${Capitalize<P & string>}`]: (e: Events[P]) => void
+  [P in keyof Events as `on${Capitalize<P & string>}`]?: (e: Events[P]) => void
 } 
 
 /**


### PR DESCRIPTION
This is an alternative to #135, which gets generic type definitions working nicely with React. Made in response to https://github.com/brave/leo/pull/135#issuecomment-1352355559