### PR TITLE
Fix `svelte-check` errors and add check to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,11 @@ jobs:
         run: |
           npm run transform-tokens
 
+      - name: Check Types
+        id: check-types
+        run: |
+          npm run check
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "build": "npm run transform-tokens && npm run gen-types && npm run gen-bindings",
     "gen-types": "node ./scripts/gen-svelte-types.js",
     "gen-bindings": "node ./scripts/gen-react-bindings.js",
+    "check": "svelte-check --compiler-warnings \"missing-custom-element-compile-options:ignore\"",
     "transform-tokens": "node ./tokens/transformTokens.js",
     "test": "jest tests --coverage=false",
     "transform:android": "node ./examples/android/build.js",

--- a/web-components/button/button.svelte
+++ b/web-components/button/button.svelte
@@ -47,7 +47,7 @@
   export let isDisabled: Disabled = undefined
   export let href: Href = undefined
 
-  $: tag = href ? 'a' : 'button'
+  $: tag = href ? 'a' : 'button' as 'a' | 'button'
 
   const dispatch = createEventDispatcher()
 
@@ -62,6 +62,7 @@
 <svelte:element
   this={tag}
   href={href || undefined}
+  disabled={isDisabled || undefined}
   class="leoButton"
   class:isPrimary={kind === 'primary'}
   class:isSecondary={kind === 'secondary'}
@@ -71,7 +72,6 @@
   class:isMedium={size === 'medium'}
   class:isSmall={size === 'small'}
   class:isLoading
-  disabled={isDisabled || undefined}
   on:click={onClick}
   {...$$restProps}
 >

--- a/web-components/navdots/navdots.svelte
+++ b/web-components/navdots/navdots.svelte
@@ -23,13 +23,12 @@
 </script>
 
 <nav class="leo-navdots" aria-label={label}>
-  <ol class="dot-container" part="dot-container" bind:this={container}>
+  <ol class="dot-container" bind:this={container}>
     {#each dots as dot}
       <li>
         <button
           class="dot"
           class:active={dot == activeDot}
-          part="dot"
           aria-current={dot === activeDot}
           aria-label={getDotLabel(dot, dot === activeDot)}
           on:click={() => setActive(dot)}
@@ -37,7 +36,7 @@
       </li>
     {/each}
 
-    <li aria-hidden="true" class="active-dot" part="active-dot" />
+    <li aria-hidden="true" class="active-dot" />
   </ol>
 </nav>
 


### PR DESCRIPTION
I merged the `svelte-check` PR here but the new `svelte-check` is a bit stricter and I noticed it was complaining about some previously valid code.

In addition, I'm running `svelte-check` as part of CI, so we'll catch regressions. In future, it'd be good to enable the `--fail-on-warnings` flag but at the moment there's no way of whitelisting our `@theme` at rule