### PR TITLE
Changes to Leo to make it more usable from Brave Core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "svelte-loader": "3.1.4"
       },
       "peerDependencies": {
-        "typescript": "4.9.4"
+        "typescript": "^4.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "svelte-loader": "3.1.4"
   },
   "peerDependencies": {
-    "typescript": "4.9.4"
+    "typescript": "^4.0.0"
   },
   "scripts": {
     "install": "npm run build",

--- a/scripts/gen-react-bindings.js
+++ b/scripts/gen-react-bindings.js
@@ -51,9 +51,12 @@ const getReactFileContents = async (svelteFilePath) => {
 import type * as React from 'react';
 import SvelteToReact, { type ReactProps } from '${svelteReactWrapperRelativePath}';
 import ${componentName} from './${fileName}';
-import type { ${componentName}Events, ${componentName}Props } from './${fileName}';
+import type { ${componentName}Events as SvelteEvents, ${componentName}Props as SvelteProps } from './${fileName}';
+
+export type ${componentName}Props = ReactProps<SvelteProps${propParams}, SvelteEvents${propParams}>;
+export type ${componentName}Ref = HTMLElement & ${componentName}Props;
 const Untyped = SvelteToReact('${COMPONENT_PREFIX}-${fileNameWithoutExtension}', ${componentName});
-export default function ${componentName}React${funcConstraints}(props: React.PropsWithChildren<ReactProps<${componentName}Props${propParams}, ${componentName}Events${propParams}>>) {
+export default function ${componentName}React${funcConstraints}(props: React.PropsWithChildren<${componentName}Props>) {
     return Untyped(props)
 }
     `.trim();

--- a/scripts/gen-react-bindings.js
+++ b/scripts/gen-react-bindings.js
@@ -53,12 +53,9 @@ import SvelteToReact, { type ReactProps } from '${svelteReactWrapperRelativePath
 import ${componentName} from './${fileName}';
 import type { ${componentName}Events as SvelteEvents, ${componentName}Props as SvelteProps } from './${fileName}';
 
-export type ${componentName}Props = ReactProps<SvelteProps${propParams}, SvelteEvents${propParams}>;
-export type ${componentName}Ref = HTMLElement & ${componentName}Props;
-const Untyped = SvelteToReact('${COMPONENT_PREFIX}-${fileNameWithoutExtension}', ${componentName});
-export default function ${componentName}React${funcConstraints}(props: React.PropsWithChildren<${componentName}Props>) {
-    return Untyped(props)
-}
+export type ${componentName}Props${funcConstraints} = ReactProps<SvelteProps${propParams}, SvelteEvents${propParams}>;
+const ${componentName}React = SvelteToReact('${COMPONENT_PREFIX}-${fileNameWithoutExtension}', ${componentName}) as unknown as ${funcConstraints}(props: React.PropsWithChildren<${componentName}Props${propParams}>) => JSX.Element;
+export default ${componentName}React;
     `.trim();
 
     return fileContents

--- a/todo.md
+++ b/todo.md
@@ -1,5 +1,0 @@
-# TODO:
-- [x] Support passing in refs
-- [ ] Support changing opacity of navdots
-- [ ] Add support for TSC compile?
-- [ ] Maybe compile everything at install?

--- a/todo.md
+++ b/todo.md
@@ -1,5 +1,5 @@
 # TODO:
-- [ ] Support passing in refs
+- [x] Support passing in refs
 - [ ] Support changing opacity of navdots
 - [ ] Add support for TSC compile?
 - [ ] Maybe compile everything at install?

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,5 @@
+# TODO:
+- [ ] Support passing in refs
+- [ ] Support changing opacity of navdots
+- [ ] Add support for TSC compile?
+- [ ] Maybe compile everything at install?

--- a/web-components/navdots/navdots.stories.svelte
+++ b/web-components/navdots/navdots.stories.svelte
@@ -12,7 +12,7 @@
   title="Nav Dots"
   component={NavDots}
   argTypes={{
-    dots: { control: 'number', defaultValue: 10 },
+    dotCount: { control: 'number', defaultValue: 10 },
     dotSize: { control: 'number', defaultValue: 8 },
     activeColor: { control: 'color' },
     defaultColor: { control: 'color' },
@@ -21,7 +21,7 @@
 
 <Template let:args>
   <div style={`--leo-navdots-active-color: ${args.activeColor || 'unset'}; --leo-navdots-color: ${args.defaultColor || 'unset'}`}>
-    <NavDots dotCount={args.dots} {activeDot} on:change={handleChange} />
+    <NavDots {activeDot} on:change={handleChange} {...args} />
   </div>
 </Template>
 

--- a/web-components/navdots/navdots.stories.svelte
+++ b/web-components/navdots/navdots.stories.svelte
@@ -20,7 +20,7 @@
 />
 
 <Template let:args>
-  <div style={`--color-interaction-button-primary-background: ${args.activeColor || 'unset'}; --color-primary-20: ${args.defaultColor || 'unset'}`}>
+  <div style={`--leo-navdots-active-color: ${args.activeColor || 'unset'}; --leo-navdots-color: ${args.defaultColor || 'unset'}`}>
     <NavDots dotCount={args.dots} {activeDot} on:change={handleChange} />
   </div>
 </Template>

--- a/web-components/navdots/navdots.svelte
+++ b/web-components/navdots/navdots.svelte
@@ -4,7 +4,7 @@
   import { createEventDispatcher } from 'svelte'
 
   export let dotCount: number
-  export let activeDot: number
+  export let activeDot: number = 0
   export let getDotLabel: (dot: number, isCurrent: boolean) => string = (dot) =>
     `Page ${dot + 1}`
   export let label: string = 'Pagination'

--- a/web-components/navdots/navdots.svelte
+++ b/web-components/navdots/navdots.svelte
@@ -41,21 +41,23 @@
 </nav>
 
 <style lang="scss">
-  :root {
-    --dot-size: 8px;
-    --dot-spacing: 10px;
-    --dot-vertical-margin: 1px;
-    --current-dot: 0;
-    --transition-duration: 0.2s;
-    --transition-easing: ease-in-out;
-
-    // Expanded dot grows to fill half spacing in each direction.
-    --expanded-dot-size: calc(var(--dot-size) + var(--dot-spacing));
-
-    width: 100%;
-  }
-
   .leo-navdots {
+    --dot-size: var(--leo-navdots-size, 8px);
+    // Expanded dot grows to fill half spacing in each direction.
+    --expanded-dot-size: var(--leo-navdots-expanded-size, calc(var(--dot-size) + var(--dot-spacing)));
+
+    --dot-spacing: var(--leo-navdots-spacing, 10px);
+    --dot-vertical-margin: var(--leo-navdots-vertical-margin, 1px);
+    --transition-duration: var(--leo-navdots-transition-duration, 0.2s);
+    --transition-easing: var(--leo-navdots-easing, ease-in-out);
+    
+    --active-dot-color: var(--leo-navdots-active-color, var(--color-interaction-button-primary-background));
+    --active-dot-color-hover: var(--leo-navdots-active-color-hover, var(--color-icon-interactive));
+    --dot-color: var(--leo-navdots-color, var(--color-primary-20));
+    --dot-color-hover: var(--leo-navdots-color-hover, var(--color-primary-30));
+    
+    --current-dot: 0;
+
     display: flex;
     flex-direction: row;
     justify-content: center;
@@ -86,13 +88,13 @@
       width: var(--dot-size);
       height: var(--dot-size);
       border-radius: var(--dot-size);
-      background: var(--color-primary-20);
+      background: var(--dot-color);
       transition: background-color var(--transition-duration)
           var(--transition-easing),
         box-shadow var(--transition-duration) var(--transition-easing);
 
       &:hover {
-        background-color: var(--color-primary-30);
+        background-color: var(--leo-navdots-color-hover);
       }
 
       &:focus-visible:not(.active) {
@@ -116,10 +118,10 @@
       width: calc(var(--dot-size) + var(--dot-spacing));
       height: calc(var(--dot-size) + var(--dot-vertical-margin) * 2);
       border-radius: var(--dot-size);
-      background: var(--color-interaction-button-primary-background);
+      background: var(--active-dot-color);
 
       &:hover {
-        background: var(--color-icon-interactive);
+        background: var(--active-dot-color-hover);
       }
     }
   }

--- a/web-components/navdots/navdots.svelte
+++ b/web-components/navdots/navdots.svelte
@@ -3,6 +3,7 @@
 <script lang="ts">
   import { createEventDispatcher } from 'svelte'
 
+  export let animateSlide: boolean = true
   export let dotCount: number
   export let activeDot: number = 0
   export let getDotLabel: (dot: number, isCurrent: boolean) => string = (dot) =>
@@ -13,9 +14,10 @@
   $: container?.setAttribute('style', `--current-dot: ${activeDot}`)
   $: dots = Array.from(Array(dotCount), (_, i) => i)
 
-  let dispatch = createEventDispatcher<{
-    change: { activeDot: number }
-  }>()
+  let dispatch =
+    createEventDispatcher<{
+      change: { activeDot: number }
+    }>()
 
   function setActive(dot: number) {
     dispatch('change', { activeDot: dot })
@@ -36,7 +38,11 @@
       </li>
     {/each}
 
-    <li aria-hidden="true" class="active-dot" />
+    <li
+      aria-hidden="true"
+      class="active-dot"
+      class:no-animate={!animateSlide}
+    />
   </ol>
 </nav>
 
@@ -44,18 +50,27 @@
   .leo-navdots {
     --dot-size: var(--leo-navdots-size, 8px);
     // Expanded dot grows to fill half spacing in each direction.
-    --expanded-dot-size: var(--leo-navdots-expanded-size, calc(var(--dot-size) + var(--dot-spacing)));
+    --expanded-dot-size: var(
+      --leo-navdots-expanded-size,
+      calc(var(--dot-size) + var(--dot-spacing))
+    );
 
     --dot-spacing: var(--leo-navdots-spacing, 10px);
     --dot-vertical-margin: var(--leo-navdots-vertical-margin, 1px);
     --transition-duration: var(--leo-navdots-transition-duration, 0.2s);
     --transition-easing: var(--leo-navdots-easing, ease-in-out);
-    
-    --active-dot-color: var(--leo-navdots-active-color, var(--color-interaction-button-primary-background));
-    --active-dot-color-hover: var(--leo-navdots-active-color-hover, var(--color-icon-interactive));
+
+    --active-dot-color: var(
+      --leo-navdots-active-color,
+      var(--color-interaction-button-primary-background)
+    );
+    --active-dot-color-hover: var(
+      --leo-navdots-active-color-hover,
+      var(--color-icon-interactive)
+    );
     --dot-color: var(--leo-navdots-color, var(--color-primary-20));
     --dot-color-hover: var(--leo-navdots-color-hover, var(--color-primary-30));
-    
+
     --current-dot: 0;
 
     display: flex;
@@ -101,6 +116,10 @@
         box-shadow: 0px 0px 0px 1.5px rgba(255, 255, 255, 0.5),
           0px 0px 4px 2px #423eee;
       }
+    }
+
+    .no-animate {
+      --transition-duration: 0;
     }
 
     .active-dot {

--- a/web-components/svelte-react.ts
+++ b/web-components/svelte-react.ts
@@ -32,7 +32,6 @@ export type ReactProps<Props, Events> = Props & {
  * @returns A react component
  */
 export default function SvelteWebComponentToReact<T extends Record<string, any>> (tag: string, component: typeof SvelteComponent) {
-  console.log(component)
   return function ReactSvelteWebComponent (props: React.PropsWithChildren<T>) {
     const component = useRef<SvelteComponent>()
     
@@ -96,8 +95,18 @@ export default function SvelteWebComponentToReact<T extends Record<string, any>>
     }, [])
 
     useEffect(() => {
+      // Create a dictionary of all our properties without events. If we pass an
+      // onClick prop through to Svelte, we could inadvertently set it on the
+      // HTMLElement if we use <el {...$restProps}/>, which causes a Svelte to
+      // setAttribute('onClick', props['onClick']). This can lead to unexpected
+      // behavior, and triggers a TrustedTypes error.
+      const propsSansEvents = { ...props }
+      for (const event of Object.keys(props).filter(name => eventRegex.test(name))) {
+        delete propsSansEvents[event]
+      }
+
       if (component.current) {
-        component.current.$set(props)
+        component.current.$set(propsSansEvents)
       }
     }, [props])
 

--- a/web-components/svelte-react.ts
+++ b/web-components/svelte-react.ts
@@ -1,6 +1,5 @@
-import * as React from "react"
-import { useRef, useEffect, forwardRef, ForwardedRef } from 'react'
-import { SvelteComponent, SvelteComponentTyped } from "svelte"
+import { createElement, useRef, useEffect, forwardRef, useCallback, type ForwardedRef, type PropsWithChildren } from "react"
+import type { SvelteComponent, SvelteComponentTyped } from "svelte"
 
 const eventRegex = /on([A-Z]{1,}[a-zA-Z]*)/
 const watchRegex = /watch([A-Z]{1,}[a-zA-Z]*)/
@@ -24,6 +23,8 @@ export type SvelteProps<T> = T extends SvelteComponentTyped<infer Props, any, an
 export type SvelteEvents<T> = T extends SvelteComponentTyped<any, infer Events, any> ? Events : {}
 export type ReactProps<Props, Events> = Props & {
   [P in keyof Events as `on${Capitalize<P & string>}`]?: (e: Events[P]) => void
+} & {
+  ref?: ForwardedRef<Props>
 }
 
 /**
@@ -33,10 +34,10 @@ export type ReactProps<Props, Events> = Props & {
  * @returns A react component
  */
 export default function SvelteWebComponentToReact<T extends Record<string, any>>(tag: string, component: typeof SvelteComponent) {
-  return forwardRef((props: React.PropsWithChildren<T>, forwardedRef: ForwardedRef<SvelteComponent>) => {
+  return forwardRef((props: PropsWithChildren<T>, forwardedRef: ForwardedRef<SvelteComponent>) => {
     const component = useRef<SvelteComponent>()
 
-    const setRef = React.useCallback((ref: SvelteComponent) => {
+    const setRef = useCallback((ref: SvelteComponent) => {
       if (!ref) {
         console.error('No component for tag', tag)
         return
@@ -123,6 +124,6 @@ export default function SvelteWebComponentToReact<T extends Record<string, any>>
       }
     }, [])
 
-    return React.createElement(tag, { ref: setRef, children: props.children })// as unknown as React.ReactElement<T>
+    return createElement(tag, { ref: setRef, children: props.children })
   })
 }


### PR DESCRIPTION
This isn't 100% complete but is pretty useful as-is. Our major blockers are:
1. Patch Svelte to not break out CSP https://github.com/sveltejs/svelte/pull/8135
2. Work out some strategy for compiling Leo for consumers which aren't already using Svelte. Current dependencies Leo adds to brave-core:
    1. @brave/leo
    2. css-tree
    3. svelte
    4. postcss
    5. svelte-loader
    6. svelte-preprocess
   
    which seems somewhat excessive.