### PR TITLE
Add CODEOWNERS as part of security review

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @fallaciousreasoning @petemill @alanbreck


### PR DESCRIPTION
This is in preparation of adding Leo as a brave-core dependency in https://github.com/brave/brave-core/pull/16787

On @kdenhartog's recommendation I've just added @petemill, @AlanBreck and myself as owners. Happy to add anyone else who seems sensible.