### PR TITLE
Don't rennovate peerDependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,5 +7,11 @@
     "renovate"
   ],
   "prConcurrentLimit": 4,
-  "rangeStrategy": "pin"
+  "rangeStrategy": "pin",
+  "packageRules": [
+    {
+      "depTypeList": ["peerDependencies"],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
We want them to be as permissive as possible, rather than forcing all consumers of Leo to be up to date (even though that would be ideal.

See here for source:
https://github.com/renovatebot/renovate/issues/323#issuecomment-629139930