### PR TITLE
Ignore install scripts for npm packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,9 @@ jobs:
             ${{ runner.os }}-npm-
 
       - name: Install dependencies
-        run: npm ci
+        run: |
+          npm ci --ignore-scripts
+          npm rebuild style-dictionary-create-react-app
 
       - name: Build Leo
         id: build-leo

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Install dependencies
         run: |
           npm ci --ignore-scripts
+          # Please check with Brave's security team prior to adding any packages to this list.
           npm rebuild style-dictionary-create-react-app
 
       - name: Build Leo


### PR DESCRIPTION
This allows us to avoid running install scripts, like [this one from `core-js-pure`](https://github.com/brave/leo/pull/181#issuecomment-1405099072).

This protects us [against some supply chain attacks](https://dev.to/naugtur/get-safe-and-remain-productive-with-can-i-ignore-scripts-2ddc). We can periodically use [can-i-ignore-scripts](https://www.npmjs.com/package/can-i-ignore-scripts) to determine if we need to allow any more by including in the `npm build ...` line.