### PR TITLE
HTMLElement Props Support

### DIFF
--- a/examples/example-ui-react/public/index.html
+++ b/examples/example-ui-react/public/index.html
@@ -9,6 +9,24 @@
     />
     <link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap" rel="stylesheet">
     <title>React App</title>
+    <style>
+      @keyframes spin {
+        from {
+          transform: rotate(0deg);
+        }
+
+        to {
+          transform: rotate(360deg);
+        }
+      }
+
+      .spin {
+        animation-duration: 2s;
+        animation-name: spin;
+        animation-iteration-count: infinite;
+        animation-timing-function: linear;
+      }
+    </style>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/examples/example-ui-react/src/App.tsx
+++ b/examples/example-ui-react/src/App.tsx
@@ -5,12 +5,8 @@ import styles from './App.module.css';
 
 function App() {
   // Verify that we can change props and children (slots)
-  const [acted, setActed] = React.useState(false)
-  React.useEffect(() => {
-    setTimeout(() => setActed(true), 4000)
-  }, [])
-
   const [buttonText, setButtonText] = React.useState('I am a LEO Button');
+  const [spinning, setSpinning] = React.useState(false);
 
   return (
     <div className={styles['App']}>
@@ -21,10 +17,12 @@ function App() {
           <input type="text" value={buttonText} onChange={e => setButtonText(e.target.value)} />
         </label>
         <LeoButton
+          className={spinning ? 'spin' : ''}
           kind='primary'
           size='large'
           onClick={() => {
             location.hash = ''
+            setSpinning(s => !s)
             alert('clicked!')
           }}
         >

--- a/src/components/svelte-react.ts
+++ b/src/components/svelte-react.ts
@@ -119,10 +119,10 @@ export default function SvelteWebComponentToReact<T extends Record<string, any>>
       // setAttribute('onClick', props['onClick']). This can lead to unexpected
       // behavior, and triggers a TrustedTypes error.
       const componentProps = { ...props }
-      for (const event of Object.keys(props)
-        // Filter out events - these are handled specially
+      for (const reserved of Object.keys(props)
+        // Filter out events & intrinsicProps - these are handled specially
         .filter(name => eventRegex.test(name) || intrinsicPropsSet.has(name))) {
-        delete componentProps[event]
+        delete componentProps[reserved]
       }
 
       if (component.current) {
@@ -141,7 +141,7 @@ export default function SvelteWebComponentToReact<T extends Record<string, any>>
     // All intrinsic props are passed directly to the web component, rather than
     // being set on the underlying Svelte component.
     const wcProps = useMemo(() => {
-      const result = {}
+      const result: any = {}
       for (const key of intrinsicProps) {
         if (!(key in props)) continue
         // Note: React doesn't handle properties called |class| properly.


### PR DESCRIPTION
This makes it possible to add a whitelisted set of HTMLElement props to the WebComponent. This will allow us to style Leo components with `styled-components` and set common properties, like `style`, `id` and `className` on our Leo components.

It will enable styling like the following:

```ts
import styled from 'styled-components'
import Navdots from '@brave/leo/react/navdots'

const StylishDots = styled(Navdots)`
    --leo-navdots-active-color: hotpink;
    margin-top: 100000px;
`
```