### PR TITLE
Fix broken build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,11 +55,6 @@ jobs:
         run: |
           npm run transform-tokens
 
-      - name: Format
-        id: format
-        run: |
-          npm run format-diff
-
       - name: Check Types
         id: check-types
         run: |


### PR DESCRIPTION
I messed up a merge and the `format` section was present twice, causing the builds to not run.