### PR TITLE
Progress Improvements

### DIFF
--- a/.storybook/argHelper.ts
+++ b/.storybook/argHelper.ts
@@ -1,0 +1,7 @@
+export const getStyleFromArgs = (args) =>
+    Object.entries(args)
+        .filter(([key]) => key.startsWith('--leo-'))
+        .reduce(
+            (prev, [key, value]) => prev + `${key}: ${value || 'unset'}; `,
+            ''
+        )

--- a/.storybook/argHelper.ts
+++ b/.storybook/argHelper.ts
@@ -1,7 +1,4 @@
 export const getStyleFromArgs = (args) =>
-    Object.entries(args)
-        .filter(([key]) => key.startsWith('--leo-'))
-        .reduce(
-            (prev, [key, value]) => prev + `${key}: ${value || 'unset'}; `,
-            ''
-        )
+  Object.entries(args)
+    .filter(([key]) => key.startsWith('--leo-'))
+    .reduce((prev, [key, value]) => prev + `${key}: ${value || 'unset'}; `, '')

--- a/src/components/label/label.stories.svelte
+++ b/src/components/label/label.stories.svelte
@@ -1,23 +1,9 @@
 <script>
   import { Meta, Story, Template } from '@storybook/addon-svelte-csf'
   import Icon from '../icon/icon.svelte'
+  import { getStyleFromArgs } from '../../../.storybook/argHelper'
 
   import Label, { colors, modes } from './label.svelte'
-
-  const variables = {
-    '--leo-label-icon-size': 'number',
-    '--leo-label-font-text': 'string',
-    '--leo-label-padding': 'number',
-    '--leo-label-radius': 'number'
-  }
-
-  const getStyle = (args) =>
-    Object.entries(args)
-      .filter(([key]) => key.startsWith('--leo-'))
-      .reduce(
-        (prev, [key, value]) => prev + `${key}: ${value || 'unset'}; `,
-        ''
-      )
 </script>
 
 <Meta
@@ -67,7 +53,7 @@
 />
 
 <Template let:args>
-  <div style={getStyle(args)}>
+  <div style={getStyleFromArgs(args)}>
     <Label {...args}>
       {#if args.leftIcon}
         <Icon name={args.leftIcon} />
@@ -81,7 +67,7 @@
 </Template>
 
 <Story name="All" let:args>
-  <div class="column" style={getStyle(args)}>
+  <div class="column" style={getStyleFromArgs(args)}>
     {#each colors as color}
       {#each modes as mode}
         <Label {color} {mode}>

--- a/src/components/progress/progressBar.stories.svelte
+++ b/src/components/progress/progressBar.stories.svelte
@@ -1,37 +1,36 @@
 <script lang="ts">
-    import { Meta, Story, } from '@storybook/addon-svelte-csf'
-    import Bar from './progressBar.svelte'
-    import { getStyleFromArgs } from '../../../.storybook/argHelper';
-  </script>
-  
-  <Meta
-    title="Progress Bar"
-    component={Bar}
-    argTypes={{
-      '--leo-progressbar-radius': {
-        type: 'string',
-        description: 'The border radius of the progress bar',
-      },
-      '--leo-progressbar-height': {
-        type: 'string',
-        description: 'The height of the progress bar'
-      },
-      '--leo-progressbar-background-color': {
-        type: 'string',
-        control: 'color',
-        description: 'The background color of the progress bar'
-      },
-      '--leo-progressbar-color': {
-        type: 'string',
-        control: 'color',
-        description: 'The color of the progress on the progress bar'
-      }
-    }}
-  />
-  
-  <Story name="Bar" let:args>
-    <div style={getStyleFromArgs(args)}>
-      <Bar {...args} />
-    </div>
-  </Story>
-  
+  import { Meta, Story } from '@storybook/addon-svelte-csf'
+  import Bar from './progressBar.svelte'
+  import { getStyleFromArgs } from '../../../.storybook/argHelper'
+</script>
+
+<Meta
+  title="Progress Bar"
+  component={Bar}
+  argTypes={{
+    '--leo-progressbar-radius': {
+      type: 'string',
+      description: 'The border radius of the progress bar'
+    },
+    '--leo-progressbar-height': {
+      type: 'string',
+      description: 'The height of the progress bar'
+    },
+    '--leo-progressbar-background-color': {
+      type: 'string',
+      control: 'color',
+      description: 'The background color of the progress bar'
+    },
+    '--leo-progressbar-color': {
+      type: 'string',
+      control: 'color',
+      description: 'The color of the progress on the progress bar'
+    }
+  }}
+/>
+
+<Story name="Bar" let:args>
+  <div style={getStyleFromArgs(args)}>
+    <Bar {...args} />
+  </div>
+</Story>

--- a/src/components/progress/progressBar.stories.svelte
+++ b/src/components/progress/progressBar.stories.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+    import { Meta, Story, } from '@storybook/addon-svelte-csf'
+    import Bar from './progressBar.svelte'
+  </script>
+  
+  <Meta
+    title="Progress Bar"
+    component={Bar}
+    argTypes={{
+      '--leo-progressbar-radius': {
+        type: 'number',
+        description: 'The border radius of the progress bar',
+      },
+      '--leo-progressbar-background-color': {
+        type: 'string',
+        control: 'color',
+        description: 'The background color of the progress bar'
+      },
+      '--leo-progressbar-color': {
+        type: 'string',
+        control: 'color',
+        description: 'The color of the progress on the progress bar'
+      }
+    }}
+  />
+  
+  <Story name="Bar" let:args>
+    <div
+      style:--leo-progress-color={args.strokeColor || 'unset'}
+      style:--leo-progress-background-color={args.backgroundColor || 'unset'}
+    >
+      <Bar {...args} />
+    </div>
+  </Story>
+  

--- a/src/components/progress/progressBar.stories.svelte
+++ b/src/components/progress/progressBar.stories.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { Meta, Story, } from '@storybook/addon-svelte-csf'
     import Bar from './progressBar.svelte'
+    import { getStyleFromArgs } from '../../../.storybook/argHelper';
   </script>
   
   <Meta
@@ -8,8 +9,12 @@
     component={Bar}
     argTypes={{
       '--leo-progressbar-radius': {
-        type: 'number',
+        type: 'string',
         description: 'The border radius of the progress bar',
+      },
+      '--leo-progressbar-height': {
+        type: 'string',
+        description: 'The height of the progress bar'
       },
       '--leo-progressbar-background-color': {
         type: 'string',
@@ -25,10 +30,7 @@
   />
   
   <Story name="Bar" let:args>
-    <div
-      style:--leo-progress-color={args.strokeColor || 'unset'}
-      style:--leo-progress-background-color={args.backgroundColor || 'unset'}
-    >
+    <div style={getStyleFromArgs(args)}>
       <Bar {...args} />
     </div>
   </Story>

--- a/src/components/progress/progressBar.svelte
+++ b/src/components/progress/progressBar.svelte
@@ -21,7 +21,7 @@
       width: 100%;
       transition: width var(--transition-duration) ease-in-out;
       background: var(
-        --leo-progress-color,
+        --leo-progressbar-color,
         var(--color-interaction-button-primary-background)
       );
       border-radius: var(--radius);

--- a/src/components/progress/progressBar.svelte
+++ b/src/components/progress/progressBar.svelte
@@ -12,7 +12,10 @@
   .leo-progressbar {
     --radius: var(--leo-progressbar-radius, 10px);
     --transition-duration: var(--leo-progressbar-transition-duration, 0.2s);
-    background: var(--leo-progressbar-background-color, var(--color-primary-20));
+    background: var(
+      --leo-progressbar-background-color,
+      var(--color-primary-20)
+    );
     height: var(--leo-progressbar-height, 4px);
     border-radius: var(--radius);
 

--- a/src/components/progress/progressBar.svelte
+++ b/src/components/progress/progressBar.svelte
@@ -12,7 +12,7 @@
   .leo-progressbar {
     --radius: var(--leo-progressbar-radius, 10px);
     --transition-duration: var(--leo-progressbar-transition-duration, 0.2s);
-    background: var(--leo-progress-background-color, var(--color-primary-20));
+    background: var(--leo-progressbar-background-color, var(--color-primary-20));
     height: var(--leo-progressbar-height, 4px);
     border-radius: var(--radius);
 

--- a/src/components/progress/progressRing.stories.svelte
+++ b/src/components/progress/progressRing.stories.svelte
@@ -23,6 +23,10 @@
       control: 'color',
       description: 'The color of the progress ring'
     },
+    '--leo-progressring-size': {
+      type: 'string',
+      description: 'The size of the progress ring'
+    },
     mode: {
       type: 'string',
       description: 'The mode of the progress indicator',

--- a/src/components/progress/progressRing.stories.svelte
+++ b/src/components/progress/progressRing.stories.svelte
@@ -2,39 +2,45 @@
   import { Meta, Story } from '@storybook/addon-svelte-csf'
   import Ring from './progressRing.svelte'
   import Icon from '../icon/icon.svelte'
+  import { getStyleFromArgs } from '../../../.storybook/argHelper'
 </script>
 
 <Meta
   title="Progress Ring"
   component={Ring}
   argTypes={{
-    strokeColor: {
-      name: 'color',
+    '--leo-progressring-spin-rate': {
       type: 'string',
-      control: 'color'
+      description: 'The rate that the indeterminate spinner spins at'
     },
-    backgroundColor: {
-      name: 'background',
+    '--leo-progressring-color': {
       type: 'string',
-      control: 'color'
+      control: 'color',
+      description: 'The color of the progress on the progress ring'
+    },
+    '--leo-progressring-background-color': {
+      type: 'string',
+      control: 'color',
+      description: 'The color of the progress ring'
+    },
+    mode: {
+      type: 'string',
+      description: 'The mode of the progress indicator',
+      control: 'select',
+      options: ['determinate', 'indeterminate'],
+      defaultValue: 'indeterminate'
     }
   }}
 />
 
 <Story name="Ring" let:args>
-  <div
-    style:--leo-progress-color={args.strokeColor || 'unset'}
-    style:--leo-progress-background-color={args.backgroundColor || 'unset'}
-  >
+  <div style={getStyleFromArgs(args)}>
     <Ring {...args} />
   </div>
 </Story>
 
 <Story name="Ring Icon" let:args>
-  <div
-    style:--leo-progress-color={args.strokeColor || 'unset'}
-    style:--leo-progress-background-color={args.backgroundColor || 'unset'}
-  >
+  <div style={getStyleFromArgs(args)}>
     <Ring {...args}>
       <div style="color: var(--color-icon-default)">
         <Icon name="notification" />

--- a/src/components/progress/progressRing.stories.svelte
+++ b/src/components/progress/progressRing.stories.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
-  import { Meta, Story, Template } from '@storybook/addon-svelte-csf'
+  import { Meta, Story } from '@storybook/addon-svelte-csf'
   import Ring from './progressRing.svelte'
-  import Bar from './progressBar.svelte'
   import Icon from '../icon/icon.svelte'
 </script>
 
 <Meta
-  title="Progress Components"
+  title="Progress Ring"
   component={Ring}
   argTypes={{
     strokeColor: {
@@ -41,14 +40,5 @@
         <Icon name="notification" />
       </div>
     </Ring>
-  </div>
-</Story>
-
-<Story name="Bar" let:args>
-  <div
-    style:--leo-progress-color={args.strokeColor || 'unset'}
-    style:--leo-progress-background-color={args.backgroundColor || 'unset'}
-  >
-    <Bar {...args} />
   </div>
 </Story>

--- a/src/components/progress/progressRing.svelte
+++ b/src/components/progress/progressRing.svelte
@@ -53,12 +53,12 @@
     --spin-rate: var(--leo-progressring-spin-rate, 1s);
     --transition-duration: var(--leo-progressring-transition-duration, 0.2s);
     --stroke-color: var(
-      --leo-progress-color,
+      --leo-progressring-color,
       var(--color-interaction-button-primary-background)
     );
 
     --background-color: var(
-      --leo-progress-background-color,
+      --leo-progressring-background-color,
       var(--color-primary-20)
     );
 

--- a/src/components/progress/progressRing.svelte
+++ b/src/components/progress/progressRing.svelte
@@ -2,40 +2,31 @@
 
 <script lang="ts">
   export let progress = 0
-  export let radius = 24
-  export let strokeWidth = 4
   export let mode: 'determinate' | 'indeterminate' = 'indeterminate'
 
   $: progress = mode === 'indeterminate' ? 0.25 : progress
-
-  $: normalizedRadius = radius - strokeWidth
-  $: circumference = normalizedRadius * 2 * Math.PI
 </script>
 
-<div
-  class="leo-progressring"
-  class:spin={mode === 'indeterminate'}
-  style="width: {radius * 2}px; height: {radius * 2}px"
->
+<div class="leo-progressring" class:spin={mode === 'indeterminate'} style:--progress={progress}>
   <slot />
-  <svg width={radius * 2} height={radius * 2}>
+  <svg viewBox="0 0 48 48">
     <circle
-      r={normalizedRadius}
-      cx={radius}
-      cy={radius}
+      style:r="var(--normalized-radius)"
+      style:cx="var(--radius)"
+      style:cy="var(--radius)"
+      style:stroke-width="var(--stroke-width)"
       stroke="var(--background-color)"
-      stroke-width={strokeWidth}
       fill="transparent"
     />
     <circle
+      style:r="var(--normalized-radius)"
+      style:cx="var(--radius)"
+      style:cy="var(--radius)"
+      style:stroke-width="var(--stroke-width)"
       stroke="var(--stroke-color)"
-      stroke-dasharray="{circumference} {circumference}"
-      stroke-width={strokeWidth}
-      stroke-dashoffset={circumference * (1 - progress)}
+      style:stroke-dasharray="var(--circumference) var(--circumference)"
+      style:stroke-dashoffset="calc(var(--circumference) * (1 - var(--progress)))"
       fill="transparent"
-      r={normalizedRadius}
-      cx={radius}
-      cy={radius}
     />
   </svg>
 </div>
@@ -50,18 +41,25 @@
     }
   }
   .leo-progressring {
+    --size: var(--leo-progressring-size, 48px);
     --spin-rate: var(--leo-progressring-spin-rate, 1s);
     --transition-duration: var(--leo-progressring-transition-duration, 0.2s);
     --stroke-color: var(
       --leo-progressring-color,
       var(--color-interaction-button-primary-background)
     );
+    --stroke-width: var(--leo-progressring-stroke-width, 4px);
+    --radius: 24px;
+    --normalized-radius: calc(var(--radius) - var(--stroke-width));
+    --circumference: calc(var(--normalized-radius) * 2 * 3.141592);
 
     --background-color: var(
       --leo-progressring-background-color,
       var(--color-primary-20)
     );
 
+    width: var(--size);
+    height: var(--size);
     position: relative;
     display: flex;
     flex-direction: column;

--- a/src/components/progress/progressRing.svelte
+++ b/src/components/progress/progressRing.svelte
@@ -7,7 +7,11 @@
   $: progress = mode === 'indeterminate' ? 0.25 : progress
 </script>
 
-<div class="leo-progressring" class:spin={mode === 'indeterminate'} style:--progress={progress}>
+<div
+  class="leo-progressring"
+  class:spin={mode === 'indeterminate'}
+  style:--progress={progress}
+>
   <slot />
   <svg viewBox="0 0 48 48">
     <circle
@@ -25,7 +29,7 @@
       style:stroke-width="var(--stroke-width)"
       stroke="var(--stroke-color)"
       style:stroke-dasharray="var(--circumference) var(--circumference)"
-      style:stroke-dashoffset="calc(var(--circumference) * (1 - var(--progress)))"
+      style:stroke-dashoffset={'calc(var(--circumference) * (1 - var(--progress)))'}
       fill="transparent"
     />
   </svg>


### PR DESCRIPTION
Fixes https://github.com/brave/leo/issues/202
- Makes the progress ring resizable (while maintaining the ability to set the stroke width & and CSS variables)
- Split the `progress` story into a `progressRing` and `progressBar` story
- Update the stories to list out the CSS variables
- Type the mode, so it's obvious what the options are