### PR TITLE
forces resolution for axios

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@ctrl/tinycolor": "3.5.0",
+        "@ctrl/tinycolor": "3.5.1",
         "@tsconfig/svelte": "3.0.0",
         "lodash.camelcase": "4.3.0",
         "lodash.merge": "4.6.2",
@@ -1965,9 +1965,9 @@
       }
     },
     "node_modules/@ctrl/tinycolor": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.5.0.tgz",
-      "integrity": "sha512-tlJpwF40DEQcfR/QF+wNMVyGMaO9FQp6Z1Wahj4Gk3CJQYHwA2xVG7iKDFdW6zuxZY9XWOpGcfNCTsX4McOsOg==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.5.1.tgz",
+      "integrity": "sha512-Bp8VF1lm91/vxFSBdVrrSe+P4KpjRCSAJ6qPSeLFnVprT/ERXHDvV2OJSJbRwl1r/KcySshTUnVbAzrSbn93fg==",
       "engines": {
         "node": ">=10"
       }
@@ -12543,9 +12543,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.2.tgz",
-      "integrity": "sha512-1M3O703bYqYuPhbHeya5bnhpYVsDDRyQSabNja04mZtboLNSuZ4YrltestrLXfHgmzua4TpUqRiVKbiQuo2epw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.3.tgz",
+      "integrity": "sha512-eYq77dYIFS77AQlhzEL937yUBSepBfPIe8FcgEDN35vMNZKMrs81pgnyrQpwfy4NF4b4XWX1Zgx7yX+25w8QJA==",
       "dev": true,
       "dependencies": {
         "follow-redirects": "^1.15.0",
@@ -14538,9 +14538,9 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.27.2",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.27.2.tgz",
-      "integrity": "sha512-9ashVQskuh5AZEZ1JdQWp1GqSoC1e1G87MzRqg2gIfVAQ7Qn9K+uFj8EcniUFA4P2NLZfV+TOlX1SzoKfo+s7w==",
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.28.0.tgz",
+      "integrity": "sha512-GiZn9D4Z/rSYvTeg1ljAIsEqFm0LaN9gVtwDCrKL80zHtS31p9BAjmTxVqTQDMpwlMolJZOFntUG2uwyj7DAqw==",
       "dev": true,
       "hasInstallScript": true,
       "funding": {
@@ -14549,12 +14549,12 @@
       }
     },
     "node_modules/core-js-compat": {
-      "version": "3.27.2",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.27.2.tgz",
-      "integrity": "sha512-welaYuF7ZtbYKGrIy7y3eb40d37rG1FvzEOfe7hSLd2iD6duMDqUhRfSvCGyC46HhR6Y8JXXdZ2lnRUMkPBpvg==",
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.28.0.tgz",
+      "integrity": "sha512-myzPgE7QodMg4nnd3K1TDoES/nADRStM8Gpz0D6nhkwbmwEnE0ZGJgoWsvQ722FR8D7xS0n0LV556RcEicjTyg==",
       "dev": true,
       "dependencies": {
-        "browserslist": "^4.21.4"
+        "browserslist": "^4.21.5"
       },
       "funding": {
         "type": "opencollective",
@@ -16971,43 +16971,6 @@
       "engines": {
         "node": ">=8.9"
       }
-    },
-    "node_modules/figma-js/node_modules/axios": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
-      "deprecated": "Critical security vulnerability fixed in v0.21.1. For more information, see https://github.com/axios/axios/pull/3410",
-      "dev": true,
-      "dependencies": {
-        "follow-redirects": "1.5.10"
-      }
-    },
-    "node_modules/figma-js/node_modules/debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/figma-js/node_modules/follow-redirects": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-      "dev": true,
-      "dependencies": {
-        "debug": "=3.1.0"
-      },
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/figma-js/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
     },
     "node_modules/figma-transformer": {
       "version": "2.1.0",
@@ -19671,16 +19634,16 @@
       }
     },
     "node_modules/jest": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-29.4.1.tgz",
-      "integrity": "sha512-cknimw7gAXPDOmj0QqztlxVtBVCw2lYY9CeIE5N6kD+kET1H4H79HSNISJmijb1HF+qk+G+ploJgiDi5k/fRlg==",
+      "version": "29.4.2",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.4.2.tgz",
+      "integrity": "sha512-+5hLd260vNIHu+7ZgMIooSpKl7Jp5pHKb51e73AJU3owd5dEo/RfVwHbA/na3C/eozrt3hJOLGf96c7EWwIAzg==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@jest/core": "^29.4.1",
-        "@jest/types": "^29.4.1",
+        "@jest/core": "^29.4.2",
+        "@jest/types": "^29.4.2",
         "import-local": "^3.0.2",
-        "jest-cli": "^29.4.1"
+        "jest-cli": "^29.4.2"
       },
       "bin": {
         "jest": "bin/jest.js"
@@ -31127,9 +31090,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.0.tgz",
-      "integrity": "sha512-kU62emKIdKVeEIOIKVegvqpXMSTAMLJozpHZaJNDYqBjzlSYXQGviYwN1osDLJ9av68qHd4a2oSjd7yD4pacig==",
+      "version": "8.12.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.1.tgz",
+      "integrity": "sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
@@ -32570,9 +32533,9 @@
       "optional": true
     },
     "@ctrl/tinycolor": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.5.0.tgz",
-      "integrity": "sha512-tlJpwF40DEQcfR/QF+wNMVyGMaO9FQp6Z1Wahj4Gk3CJQYHwA2xVG7iKDFdW6zuxZY9XWOpGcfNCTsX4McOsOg=="
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.5.1.tgz",
+      "integrity": "sha512-Bp8VF1lm91/vxFSBdVrrSe+P4KpjRCSAJ6qPSeLFnVprT/ERXHDvV2OJSJbRwl1r/KcySshTUnVbAzrSbn93fg=="
     },
     "@design-systems/utils": {
       "version": "2.12.0",
@@ -40738,9 +40701,9 @@
       "dev": true
     },
     "axios": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.2.tgz",
-      "integrity": "sha512-1M3O703bYqYuPhbHeya5bnhpYVsDDRyQSabNja04mZtboLNSuZ4YrltestrLXfHgmzua4TpUqRiVKbiQuo2epw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.3.tgz",
+      "integrity": "sha512-eYq77dYIFS77AQlhzEL937yUBSepBfPIe8FcgEDN35vMNZKMrs81pgnyrQpwfy4NF4b4XWX1Zgx7yX+25w8QJA==",
       "dev": true,
       "requires": {
         "follow-redirects": "^1.15.0",
@@ -42298,18 +42261,18 @@
       "dev": true
     },
     "core-js": {
-      "version": "3.27.2",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.27.2.tgz",
-      "integrity": "sha512-9ashVQskuh5AZEZ1JdQWp1GqSoC1e1G87MzRqg2gIfVAQ7Qn9K+uFj8EcniUFA4P2NLZfV+TOlX1SzoKfo+s7w==",
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.28.0.tgz",
+      "integrity": "sha512-GiZn9D4Z/rSYvTeg1ljAIsEqFm0LaN9gVtwDCrKL80zHtS31p9BAjmTxVqTQDMpwlMolJZOFntUG2uwyj7DAqw==",
       "dev": true
     },
     "core-js-compat": {
-      "version": "3.27.2",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.27.2.tgz",
-      "integrity": "sha512-welaYuF7ZtbYKGrIy7y3eb40d37rG1FvzEOfe7hSLd2iD6duMDqUhRfSvCGyC46HhR6Y8JXXdZ2lnRUMkPBpvg==",
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.28.0.tgz",
+      "integrity": "sha512-myzPgE7QodMg4nnd3K1TDoES/nADRStM8Gpz0D6nhkwbmwEnE0ZGJgoWsvQ722FR8D7xS0n0LV556RcEicjTyg==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.21.4"
+        "browserslist": "^4.21.5"
       }
     },
     "core-util-is": {
@@ -44226,7 +44189,7 @@
       "dev": true,
       "from": "figma-api-exporter@github:brave/figma-api-exporter#775a17babce35ed165936142caf5c5dca3490395",
       "requires": {
-        "axios": "1.3.2",
+        "axios": "^1.3.2",
         "figma-js": "1.13.0",
         "figma-transformer": "2.1.0",
         "ramda": "0.28.0",
@@ -44239,42 +44202,7 @@
       "integrity": "sha512-YBYxKHzZ3vfjxU2RldJ6ZWGaXGrXlqwef7lKgpDIIMr2dAG4xNkwLj31UiQhw1kzdkABhxiDJBJgVGMKwEogfA==",
       "dev": true,
       "requires": {
-        "axios": "^0.19.0"
-      },
-      "dependencies": {
-        "axios": {
-          "version": "0.19.2",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-          "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
-          "dev": true,
-          "requires": {
-            "follow-redirects": "1.5.10"
-          }
-        },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "follow-redirects": {
-          "version": "1.5.10",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-          "dev": true,
-          "requires": {
-            "debug": "=3.1.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-          "dev": true
-        }
+        "axios": "^1.3.2"
       }
     },
     "figma-transformer": {
@@ -46288,16 +46216,16 @@
       }
     },
     "jest": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-29.4.1.tgz",
-      "integrity": "sha512-cknimw7gAXPDOmj0QqztlxVtBVCw2lYY9CeIE5N6kD+kET1H4H79HSNISJmijb1HF+qk+G+ploJgiDi5k/fRlg==",
+      "version": "29.4.2",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.4.2.tgz",
+      "integrity": "sha512-+5hLd260vNIHu+7ZgMIooSpKl7Jp5pHKb51e73AJU3owd5dEo/RfVwHbA/na3C/eozrt3hJOLGf96c7EWwIAzg==",
       "dev": true,
       "peer": true,
       "requires": {
-        "@jest/core": "^29.4.1",
-        "@jest/types": "^29.4.1",
+        "@jest/core": "^29.4.2",
+        "@jest/types": "^29.4.2",
         "import-local": "^3.0.2",
-        "jest-cli": "^29.4.1"
+        "jest-cli": "^29.4.2"
       }
     },
     "jest-changed-files": {
@@ -55158,9 +55086,9 @@
       }
     },
     "ws": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.0.tgz",
-      "integrity": "sha512-kU62emKIdKVeEIOIKVegvqpXMSTAMLJozpHZaJNDYqBjzlSYXQGviYwN1osDLJ9av68qHd4a2oSjd7yD4pacig==",
+      "version": "8.12.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.1.tgz",
+      "integrity": "sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "type": "module",
   "dependencies": {
-    "@ctrl/tinycolor": "3.5.0",
+    "@ctrl/tinycolor": "3.5.1",
     "@tsconfig/svelte": "3.0.0",
     "lodash.camelcase": "4.3.0",
     "lodash.merge": "4.6.2",
@@ -38,7 +38,6 @@
     "css-loader": "6.7.3",
     "css-tree": "2.3.1",
     "figma-api-exporter": "github:brave/figma-api-exporter#775a17babce35ed165936142caf5c5dca3490395",
-    "ts-jest": "29.0.5",
     "jsdom": "21.1.0",
     "postcss": "8.4.21",
     "postcss-js": "4.0.1",
@@ -50,7 +49,8 @@
     "sass-loader": "13.2.0",
     "style-loader": "3.3.1",
     "svelte-loader": "3.1.5",
-    "svgo": "3.0.2"
+    "svgo": "3.0.2",
+    "ts-jest": "29.0.5"
   },
   "peerDependencies": {
     "react": ">= 16.0.0",
@@ -79,5 +79,8 @@
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "overrides": {
+    "axios": "^1.3.2"
+  }
 }


### PR DESCRIPTION
We have multiple dependapot alerts due to an [outdated version of axios which `figma-js` depends upon](https://github.com/jemgold/figma-js/blob/main/package.json#L57).

I thought about submitting a PR to the `figma-js` project, but got errors as soon as I tried `npm install` due to conflicts with `tslint`, which has apparently been deprecated since 2019.

This seems to be the path of least resistance.