### PR TITLE
Improves Skia output to make it easier to use in Brave Core

### DIFF
--- a/src/tokens/config.js
+++ b/src/tokens/config.js
@@ -60,7 +60,7 @@ module.exports = {
       buildPath: 'tokens/skia/',
       files: [
         {
-          destination: 'Colors.h',
+          destination: 'colors.h',
           format: 'skia/colors.h',
           filter: {
             type: 'color'

--- a/src/tokens/transformation/skia/templates/colors.h.template
+++ b/src/tokens/transformation/skia/templates/colors.h.template
@@ -16,3 +16,27 @@ namespace leo::dark {
   return `constexpr SkColor ${prop.name} = SkColorSetRGB(${prop.value})`;
 }).map(s => `${s};`).join('\n') %>
 } // namespace leo::dark
+
+namespace leo {
+
+enum Theme {
+  kLight,
+  kDark
+};
+
+enum Color {
+<%= groupedTokens.light.allTokens.map(prop => `  ${prop.name}`).join(',\n') %>
+};
+
+SkColor GetColor(Color color, Theme theme) {
+  switch (color) {
+<%= groupedTokens.light.allTokens.map(prop => `    case ${prop.name}:
+      return theme == Theme::kLight
+        ? leo::light::${prop.name}
+        : leo::dark::${prop.name};`).join('\n') %>
+    default:
+      return SK_ColorRED;
+  }
+}
+
+} // namespace leo

--- a/src/tokens/transformation/skia/templates/colors.h.template
+++ b/src/tokens/transformation/skia/templates/colors.h.template
@@ -19,16 +19,16 @@ namespace leo::dark {
 
 namespace leo {
 
-enum Theme {
+enum class Theme {
   kLight,
   kDark
 };
 
-enum Color {
+enum class Color {
 <%= groupedTokens.light.allTokens.map(prop => `  ${prop.name}`).join(',\n') %>
 };
 
-SkColor GetColor(Color color, Theme theme) {
+constexpr SkColor GetColor(Color color, Theme theme) {
   switch (color) {
 <%= groupedTokens.light.allTokens.map(prop => `    case ${prop.name}:
       return theme == Theme::kLight


### PR DESCRIPTION
Questions:
~1. Should I be doing substitution to make the dark colors automatically work (i.e. `kColorPrimary40` is `primary40` in light and `primary60` in dark).~ This is handled in Figma
2. Should I depend on the Chromium `PreferredColorScheme` type instead of introducing `leo::Theme::{kDark,kLight}`