### PR TITLE
[Button]: Add new button variants

### DIFF
--- a/examples/example-ui-react/src/App.tsx
+++ b/examples/example-ui-react/src/App.tsx
@@ -20,7 +20,7 @@ function App() {
             onChange={(e) => setButtonText(e.target.value)}
           />
         </label>
-        <LeoButton
+        {buttonText && <LeoButton
           className={spinning ? 'spin' : ''}
           kind="primary"
           size="large"
@@ -31,7 +31,7 @@ function App() {
           }}
         >
           {buttonText}
-        </LeoButton>
+        </LeoButton>}
         <LeoButton href="#foo">Link button!</LeoButton>
       </header>
     </div>

--- a/examples/example-ui-react/src/App.tsx
+++ b/examples/example-ui-react/src/App.tsx
@@ -20,18 +20,20 @@ function App() {
             onChange={(e) => setButtonText(e.target.value)}
           />
         </label>
-        {buttonText && <LeoButton
-          className={spinning ? 'spin' : ''}
-          kind="primary"
-          size="large"
-          onClick={() => {
-            location.hash = ''
-            setSpinning((s) => !s)
-            alert('clicked!')
-          }}
-        >
-          {buttonText}
-        </LeoButton>}
+        {buttonText && (
+          <LeoButton
+            className={spinning ? 'spin' : ''}
+            kind="filled"
+            size="large"
+            onClick={() => {
+              location.hash = ''
+              setSpinning((s) => !s)
+              alert('clicked!')
+            }}
+          >
+            {buttonText}
+          </LeoButton>
+        )}
         <LeoButton href="#foo">Link button!</LeoButton>
       </header>
     </div>

--- a/src/components/button/button.stories.svelte
+++ b/src/components/button/button.stories.svelte
@@ -40,7 +40,7 @@
     <h2 class="label capitalize">{size}</h2>
     <div class="button-group">
       {#each buttonKinds as kind}
-        <Button kind={kind} size={size} {...args}>
+        <Button {kind} {size} {...args}>
           <span class="capitalize">{kind}</span>
         </Button>
       {/each}
@@ -55,7 +55,7 @@
     gap: 24px;
     align-items: center;
   }
-  .capitalize { 
+  .capitalize {
     text-transform: capitalize;
   }
   .label {

--- a/src/components/button/button.stories.svelte
+++ b/src/components/button/button.stories.svelte
@@ -27,13 +27,13 @@
 
 <Story name="Hero" args={{ kind: 'hero' }} />
 
-<Story name="Primary" args={{ kind: 'primary' }} />
+<Story name="Filled" args={{ kind: 'filled' }} />
 
-<Story name="Secondary" source args={{ kind: 'secondary' }} />
+<Story name="Outline" source args={{ kind: 'outline' }} />
 
-<Story name="Tertiary" source args={{ kind: 'tertiary' }} />
+<Story name="Plain" source args={{ kind: 'plain' }} />
 
-<Story name="Quaternary" source args={{ kind: 'quaternary' }} />
+<Story name="Plain Faint" source args={{ kind: 'plain-faint' }} />
 
 <Story name="All" let:args>
   {#each buttonSizes as size}

--- a/src/components/button/button.stories.svelte
+++ b/src/components/button/button.stories.svelte
@@ -33,6 +33,8 @@
 
 <Story name="Tertiary" source args={{ kind: 'tertiary' }} />
 
+<Story name="Quaternary" source args={{ kind: 'quaternary' }} />
+
 <Story name="All" let:args>
   <h2 class="label">Large</h2>
   <div class="button-group">
@@ -40,6 +42,7 @@
     <Button kind="primary" size="large" {...args}>Primary</Button>
     <Button kind="secondary" size="large" {...args}>Secondary</Button>
     <Button kind="tertiary" size="large" {...args}>Tertiary</Button>
+    <Button kind="quaternary" size="large" {...args}>Quaternary</Button>
   </div>
   <h2 class="label">Medium</h2>
   <div class="button-group">
@@ -47,6 +50,7 @@
     <Button kind="primary" size="medium" {...args}>Primary</Button>
     <Button kind="secondary" size="medium" {...args}>Secondary</Button>
     <Button kind="tertiary" size="medium" {...args}>Tertiary</Button>
+    <Button kind="quaternary" size="medium" {...args}>Quaternary</Button>
   </div>
   <h2 class="label">Small</h2>
   <div class="button-group">
@@ -54,6 +58,7 @@
     <Button kind="primary" size="small" {...args}>Primary</Button>
     <Button kind="secondary" size="small" {...args}>Secondary</Button>
     <Button kind="tertiary" size="small" {...args}>Tertiary</Button>
+    <Button kind="quaternary" size="small" {...args}>Quaternary</Button>
   </div>
 </Story>
 

--- a/src/components/button/button.stories.svelte
+++ b/src/components/button/button.stories.svelte
@@ -36,30 +36,16 @@
 <Story name="Quaternary" source args={{ kind: 'quaternary' }} />
 
 <Story name="All" let:args>
-  <h2 class="label">Large</h2>
-  <div class="button-group">
-    <Button kind="hero" size="large" {...args}>Hero</Button>
-    <Button kind="primary" size="large" {...args}>Primary</Button>
-    <Button kind="secondary" size="large" {...args}>Secondary</Button>
-    <Button kind="tertiary" size="large" {...args}>Tertiary</Button>
-    <Button kind="quaternary" size="large" {...args}>Quaternary</Button>
-  </div>
-  <h2 class="label">Medium</h2>
-  <div class="button-group">
-    <Button kind="hero" size="medium" {...args}>Hero</Button>
-    <Button kind="primary" size="medium" {...args}>Primary</Button>
-    <Button kind="secondary" size="medium" {...args}>Secondary</Button>
-    <Button kind="tertiary" size="medium" {...args}>Tertiary</Button>
-    <Button kind="quaternary" size="medium" {...args}>Quaternary</Button>
-  </div>
-  <h2 class="label">Small</h2>
-  <div class="button-group">
-    <Button kind="hero" size="small" {...args}>Hero</Button>
-    <Button kind="primary" size="small" {...args}>Primary</Button>
-    <Button kind="secondary" size="small" {...args}>Secondary</Button>
-    <Button kind="tertiary" size="small" {...args}>Tertiary</Button>
-    <Button kind="quaternary" size="small" {...args}>Quaternary</Button>
-  </div>
+  {#each buttonSizes as size}
+    <h2 class="label capitalize">{size}</h2>
+    <div class="button-group">
+      {#each buttonKinds as kind}
+        <Button kind={kind} size={size} {...args}>
+          <span class="capitalize">{kind}</span>
+        </Button>
+      {/each}
+    </div>
+  {/each}
 </Story>
 
 <style>
@@ -68,6 +54,9 @@
     display: flex;
     gap: 24px;
     align-items: center;
+  }
+  .capitalize { 
+    text-transform: capitalize;
   }
   .label {
     font: 500 14px sans-serif;

--- a/src/components/button/button.svelte
+++ b/src/components/button/button.svelte
@@ -67,9 +67,11 @@
   class:isTertiary={kind === 'tertiary'}
   class:isQuaternary={kind === 'quaternary'}
   class:isHero={kind === 'hero'}
+  class:isJumbo={size === 'jumbo'}
   class:isLarge={size === 'large'}
   class:isMedium={size === 'medium'}
   class:isSmall={size === 'small'}
+  class:isTiny={size === 'tiny'}
   class:isLoading
   on:click={onClick}
   {...$$restProps}
@@ -139,6 +141,11 @@
   }
 
   // Size Variations
+  .leoButton.isTiny {
+    --icon-size: 12px;
+    font: var(--leo-font-components-button-small);
+    padding: 6px 10px;
+  }
   .leoButton.isSmall {
     --icon-size: 20px;
     font: var(--leo-font-components-button-small);
@@ -153,6 +160,11 @@
     --icon-size: 24px;
     font: var(--leo-font-components-button-large);
     padding: 12px 20px;
+  }
+  .leoButton.isJumbo {
+    --icon-size: 24px;
+    font: var(--leo-font-components-button-jumbo);
+    padding: 18px 26px;
   }
 
   // Kind Variations

--- a/src/components/button/button.svelte
+++ b/src/components/button/button.svelte
@@ -65,6 +65,7 @@
   class:isPrimary={kind === 'primary'}
   class:isSecondary={kind === 'secondary'}
   class:isTertiary={kind === 'tertiary'}
+  class:isQuaternary={kind === 'quaternary'}
   class:isHero={kind === 'hero'}
   class:isLarge={size === 'large'}
   class:isMedium={size === 'medium'}
@@ -206,6 +207,18 @@
         --color: var(--leo-color-dark-text-primary);
       }
     }
+  }
+  .leoButton.isQuaternary {
+    padding-left: 0;
+    padding-right: 0;
+    --color: var(--leo-color-gray-60);
+    --color-hover: var(--color-gray-70);
+    --box-shadow-hover: none;
+
+    &:disabled {
+      opacity: 0.5;
+    }
+
   }
   .leoButton.isHero {
     transition: var(--default-transition);

--- a/src/components/button/button.svelte
+++ b/src/components/button/button.svelte
@@ -39,7 +39,7 @@
 
   type $$Props = LinkProps | ButtonProps
 
-  export let kind: Props.ButtonKind = 'primary'
+  export let kind: Props.ButtonKind = 'filled'
   export let size: Props.ButtonSize = 'medium'
   export let isLoading: boolean = false
   export let isDisabled: Disabled = undefined
@@ -62,10 +62,10 @@
   href={href || undefined}
   disabled={isDisabled || undefined}
   class="leoButton"
-  class:isPrimary={kind === 'primary'}
-  class:isSecondary={kind === 'secondary'}
-  class:isTertiary={kind === 'tertiary'}
-  class:isQuaternary={kind === 'quaternary'}
+  class:isFilled={kind === 'filled'}
+  class:isOutline={kind === 'outline'}
+  class:isPlain={kind === 'plain'}
+  class:isPlainFaint={kind === 'plain-faint'}
   class:isHero={kind === 'hero'}
   class:isJumbo={size === 'jumbo'}
   class:isLarge={size === 'large'}
@@ -168,7 +168,7 @@
   }
 
   // Kind Variations
-  .leoButton.isPrimary {
+  .leoButton.isFilled {
     --bg: var(--leo-color-interaction-button-primary-background);
     --bg-hover: var(--leo-color-light-primary-60);
     --bg-active: var(--bg-hover);
@@ -183,7 +183,7 @@
       --bg-loading: var(--leo-color-dark-primary-60);
     }
   }
-  .leoButton.isSecondary {
+  .leoButton.isOutline {
     --bg: transparent;
     --bg-active: --leo-color-gray-20;
     --color: var(--leo-color-text-primary);
@@ -202,7 +202,7 @@
       --border-color-hover: var(--leo-color-dark-primary-40);
     }
   }
-  .leoButton.isTertiary {
+  .leoButton.isPlain {
     border-radius: 8px;
     padding-right: 0;
     padding-left: 0;
@@ -220,7 +220,7 @@
       }
     }
   }
-  .leoButton.isQuaternary {
+  .leoButton.isPlainFaint {
     padding-left: 0;
     padding-right: 0;
     --color: var(--leo-color-gray-60);

--- a/src/components/button/button.svelte
+++ b/src/components/button/button.svelte
@@ -230,7 +230,6 @@
     &:disabled {
       opacity: 0.5;
     }
-
   }
   .leoButton.isHero {
     transition: var(--default-transition);

--- a/src/components/button/button.svelte
+++ b/src/components/button/button.svelte
@@ -224,7 +224,7 @@
     padding-left: 0;
     padding-right: 0;
     --color: var(--leo-color-gray-60);
-    --color-hover: var(--color-gray-70);
+    --color-hover: var(--leo-color-gray-70);
     --box-shadow-hover: none;
 
     &:disabled {

--- a/src/components/button/props.ts
+++ b/src/components/button/props.ts
@@ -1,5 +1,17 @@
-export const buttonKinds = ['hero', 'primary', 'secondary', 'tertiary', 'quaternary'] as const
+export const buttonKinds = [
+  'hero',
+  'primary',
+  'secondary',
+  'tertiary',
+  'quaternary'
+] as const
 export type ButtonKind = (typeof buttonKinds)[number]
 
-export const buttonSizes = ['jumbo', 'large', 'medium', 'small', 'tiny'] as const
+export const buttonSizes = [
+  'jumbo',
+  'large',
+  'medium',
+  'small',
+  'tiny'
+] as const
 export type ButtonSize = (typeof buttonSizes)[number]

--- a/src/components/button/props.ts
+++ b/src/components/button/props.ts
@@ -1,5 +1,5 @@
 export const buttonKinds = ['hero', 'primary', 'secondary', 'tertiary', 'quaternary'] as const
 export type ButtonKind = (typeof buttonKinds)[number]
 
-export const buttonSizes = ['large', 'medium', 'small'] as const
+export const buttonSizes = ['jumbo', 'large', 'medium', 'small', 'tiny'] as const
 export type ButtonSize = (typeof buttonSizes)[number]

--- a/src/components/button/props.ts
+++ b/src/components/button/props.ts
@@ -1,9 +1,9 @@
 export const buttonKinds = [
   'hero',
-  'primary',
-  'secondary',
-  'tertiary',
-  'quaternary'
+  'filled',
+  'outline',
+  'plain',
+  'plain-faint'
 ] as const
 export type ButtonKind = (typeof buttonKinds)[number]
 

--- a/src/components/button/props.ts
+++ b/src/components/button/props.ts
@@ -1,4 +1,4 @@
-export const buttonKinds = ['hero', 'primary', 'secondary', 'tertiary'] as const
+export const buttonKinds = ['hero', 'primary', 'secondary', 'tertiary', 'quaternary'] as const
 export type ButtonKind = (typeof buttonKinds)[number]
 
 export const buttonSizes = ['large', 'medium', 'small'] as const


### PR DESCRIPTION
- Adds `jumbo` Size
- Adds `tiny` size
- Adds `plain-faint` variant
- Rename existing variants to match Figma
    - `primary` ==> `filled`
    - `secondary` ==> `outline`
    - `tertiary` ==> `plain`

FWIW, I need the `jumbo` size for https://www.figma.com/file/tLXWGCpNoiJxDZDdpfordj/Desktop-Settings?node-id=3641-72342&t=SemMRN4c5wM7TB9p-0 and the `plain-faint` kind