### PR TITLE
[React]: Remove incorrect warning

### DIFF
--- a/src/components/svelte-react.ts
+++ b/src/components/svelte-react.ts
@@ -116,7 +116,7 @@ export default function SvelteWebComponentToReact<
           setElement(ref)
 
           if (!ref) {
-            console.error('No component for tag', tag)
+            // Note: This will happen when the component unmounts.
             return
           }
 


### PR DESCRIPTION
The `ref` is null when the component is being unmounted, which was causing us to log a bunch of incorrect error messages