### PR TITLE
[Dependencies]: Point to upstream Svelte

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "lodash.camelcase": "4.3.0",
         "lodash.merge": "4.6.2",
         "style-dictionary": "3.7.2",
-        "svelte": "github:brave/svelte",
+        "svelte": "3.56.0",
         "svelte-check": "3.0.3",
         "svelte-preprocess": "5.0.1",
         "svelte2tsx": "0.6.1",
@@ -28189,9 +28189,9 @@
       }
     },
     "node_modules/svelte": {
-      "version": "3.55.1",
-      "resolved": "git+ssh://git@github.com/brave/svelte.git#18a68115e0092a1c515e352097c51618c6b841a1",
-      "license": "MIT",
+      "version": "3.56.0",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.56.0.tgz",
+      "integrity": "sha512-LvXiJbjdvJKwB/0CQyYpDX0q+hFqCyWmybzC2G6eK1tJJA/RSRCytTfNmjHv+RHlLuA70vWG7nXp6gbeErYvRA==",
       "engines": {
         "node": ">= 8"
       }
@@ -52880,8 +52880,9 @@
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
     },
     "svelte": {
-      "version": "git+ssh://git@github.com/brave/svelte.git#18a68115e0092a1c515e352097c51618c6b841a1",
-      "from": "svelte@github:brave/svelte"
+      "version": "3.56.0",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.56.0.tgz",
+      "integrity": "sha512-LvXiJbjdvJKwB/0CQyYpDX0q+hFqCyWmybzC2G6eK1tJJA/RSRCytTfNmjHv+RHlLuA70vWG7nXp6gbeErYvRA=="
     },
     "svelte-check": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lodash.camelcase": "4.3.0",
     "lodash.merge": "4.6.2",
     "style-dictionary": "3.7.2",
-    "svelte": "github:brave/svelte",
+    "svelte": "3.56.0",
     "svelte-check": "3.0.3",
     "svelte-preprocess": "5.0.1",
     "svelte2tsx": "0.6.1",


### PR DESCRIPTION
Once we upgrade Leo consumers we should be able to delete our fork.

https://github.com/sveltejs/svelte/issues/8134#issuecomment-1463047453