### PR TITLE
Svelte doesn't allow Web Components which contain Svelte components.

### DIFF
--- a/.storybook/main.cjs
+++ b/.storybook/main.cjs
@@ -20,7 +20,11 @@ module.exports = {
   svelteOptions: {
     preprocess: sveltePreprocess({
       postcss: {
-        plugins: [require('../src/postcss/theme')({ wrapSelector: selector => `:global(${selector})` })]
+        plugins: [
+          require('../src/postcss/theme')({
+            wrapSelector: (selector) => `:global(${selector})`
+          })
+        ]
       }
     }),
     customElement: true

--- a/.storybook/main.cjs
+++ b/.storybook/main.cjs
@@ -20,7 +20,7 @@ module.exports = {
   svelteOptions: {
     preprocess: sveltePreprocess({
       postcss: {
-        plugins: [require('../src/postcss/theme')({ wrapIn: ':global' })]
+        plugins: [require('../src/postcss/theme')({ wrapSelector: selector => `:global(${selector})` })]
       }
     }),
     customElement: true

--- a/examples/plain-html/index.html
+++ b/examples/plain-html/index.html
@@ -47,6 +47,7 @@
       <leo-collapse title="Handy dandy title">
         Some content which is hidden by default
       </leo-collapse>
+      <leo-button></leo-button>
       <leo-toggle>Togglable!</leo-toggle>
       <leo-progressring progress="0.25"></leo-progressring>
       <leo-progressbar progress="0.25"></leo-progressbar>

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "dev": "rollup -c rollup.config.js --watch",
     "update-icons": "node ./src/scripts/update-icons.js",
     "skiafy-icons": "node ./src/scripts/gen-skia-icons.js",
-    "check": "svelte-check --compiler-warnings \"missing-custom-element-compile-options:ignore\"",
+    "check": "svelte-check",
     "transform-tokens": "node ./src/tokens/transformTokens.js && tsc -p ./tsconfig-tokens.json",
     "test": "jest tests --coverage=false",
     "storybook": "start-storybook -p 6006",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -47,7 +47,11 @@ export default {
       include: 'src/components/**/*.svelte',
       preprocess: sveltePreprocess({
         postcss: {
-          plugins: [themePlugin({ wrapSelector: selector => `:global(:host-context(${selector}))` })]
+          plugins: [
+            themePlugin({
+              wrapSelector: (selector) => `:global(:host-context(${selector}))`
+            })
+          ]
         }
       }),
       // Don't emit CSS - it doesn't work properly with Web Components.

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -60,7 +60,7 @@ export default {
       // Don't emit CSS - it doesn't work properly with Web Components.
       emitCss: false,
       compilerOptions: {
-        customElement: true
+        customElement: false
       }
     }),
     resolve({ browser: true }),

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -20,6 +20,7 @@ for await (const file of getSvelteFiles(COMPONENTS_FOLDER, false)) {
 }
 
 inputs.push('./src/components/svelte-react.ts')
+inputs.push('./src/components/svelte-web.ts')
 
 export default {
   input: inputs,
@@ -29,15 +30,7 @@ export default {
     sourcemap: true,
     dir: './',
     chunkFileNames: 'shared/[hash].js',
-    entryFileNames: ({ facadeModuleId, name }) => {
-      // Web component
-      if (facadeModuleId.endsWith('.svelte')) {
-        return `web-components/${name}.js`
-      }
-
-      // Util files for Svelte, like svelte-react
-      return `svelte/[name].js`
-    },
+    entryFileNames: ({ name }) => `shared/${name}.js`,
     format: 'esm'
   },
   // React is external - Leo doesn't need it but its React bindings do. We'll

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -47,7 +47,7 @@ export default {
       include: 'src/components/**/*.svelte',
       preprocess: sveltePreprocess({
         postcss: {
-          plugins: [themePlugin({ wrapIn: ':host-context' })]
+          plugins: [themePlugin({ wrapSelector: selector => `:global(:host-context(${selector}))` })]
         }
       }),
       // Don't emit CSS - it doesn't work properly with Web Components.

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,7 +7,8 @@ import themePlugin from './src/postcss/theme.js'
 import fs from 'fs/promises'
 import path from 'path'
 import genTypes from './src/scripts/gen-svelte-types.js'
-import genBindings from './src/scripts/gen-react-bindings.js'
+import genWebBindings from './src/scripts/gen-web-bindings.js'
+import genReactBindings from './src/scripts/gen-react-bindings.js'
 import { getSvelteFiles } from './src/scripts/common.js'
 
 // Entry points are all our Svelte components + the react bindings for those
@@ -72,9 +73,12 @@ export default {
             outputDir: './svelte'
           })
 
+          // Generate Web Components
+          await genWebBindings('./src/components')
+
           // Once we have the type definitions, we can generate the React
           // wrapper.
-          await genBindings('./src/components')
+          await genReactBindings('./src/components')
         }
       }
     }

--- a/src/components/button/button.svelte
+++ b/src/components/button/button.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="leo-button" />
-
 <script lang="ts">
   import { createEventDispatcher } from 'svelte'
   import type { SvelteHTMLElements } from 'svelte/elements'

--- a/src/components/button/button.svelte
+++ b/src/components/button/button.svelte
@@ -48,6 +48,7 @@
   export let href: Href = undefined
 
   $: tag = href ? 'a' : ('button' as 'a' | 'button')
+  $: console.log($$slots)
 
   const dispatch = createEventDispatcher()
 
@@ -75,7 +76,11 @@
   on:click={onClick}
   {...$$restProps}
 >
-  <slot>Leo Button</slot>
+{#if $$slots.default}
+<slot></slot>
+{:else}
+  Leo Button
+{/if}
 </svelte:element>
 
 <style lang="scss">

--- a/src/components/button/button.svelte
+++ b/src/components/button/button.svelte
@@ -76,11 +76,7 @@
   on:click={onClick}
   {...$$restProps}
 >
-{#if $$slots.default}
-<slot></slot>
-{:else}
-  Leo Button
-{/if}
+  <slot>Leo Button</slot>
 </svelte:element>
 
 <style lang="scss">

--- a/src/components/button/button.svelte
+++ b/src/components/button/button.svelte
@@ -48,7 +48,6 @@
   export let href: Href = undefined
 
   $: tag = href ? 'a' : ('button' as 'a' | 'button')
-  $: console.log($$slots)
 
   const dispatch = createEventDispatcher()
 

--- a/src/components/collapse/collapse.svelte
+++ b/src/components/collapse/collapse.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="leo-collapse" />
-
 <script lang="ts">
   import { createEventDispatcher } from 'svelte'
 

--- a/src/components/collapse/collapse.svelte
+++ b/src/components/collapse/collapse.svelte
@@ -2,7 +2,6 @@
 
 <script lang="ts">
   import { createEventDispatcher } from 'svelte'
-  import Button from '../button/button.svelte'
 
   export let title = ''
 
@@ -55,12 +54,6 @@
     <slot />
   </div>
 </details>
-
-<Button>
-  {#if isOpenInternal}
-    {isOpenInternal && 'open'}
-  {/if}
-</Button>
 
 <style lang="scss">
   .leoCollapse {

--- a/src/components/collapse/collapse.svelte
+++ b/src/components/collapse/collapse.svelte
@@ -2,6 +2,7 @@
 
 <script lang="ts">
   import { createEventDispatcher } from 'svelte'
+  import Button from '../button/button.svelte'
 
   export let title = ''
 
@@ -54,6 +55,9 @@
     <slot />
   </div>
 </details>
+
+
+<Button>{isOpen ? 'open' : 'closed'}</Button>
 
 <style lang="scss">
   .leoCollapse {

--- a/src/components/collapse/collapse.svelte
+++ b/src/components/collapse/collapse.svelte
@@ -56,8 +56,11 @@
   </div>
 </details>
 
-
-<Button>{isOpen ? 'open' : 'closed'}</Button>
+<Button>
+  {#if isOpenInternal}
+    {isOpenInternal && 'open'}
+  {/if}
+</Button>
 
 <style lang="scss">
   .leoCollapse {

--- a/src/components/icon/icon.svelte
+++ b/src/components/icon/icon.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="leo-icon" />
-
 <script context="module" lang="ts">
   let iconBasePath = '/icons'
   export const setIconBasePath = (basePath: string) => (iconBasePath = basePath)

--- a/src/components/label/label.svelte
+++ b/src/components/label/label.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="leo-label" />
-
 <script context="module" lang="ts">
   export const colors = [
     'gray',

--- a/src/components/link/link.svelte
+++ b/src/components/link/link.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="leo-link" />
-
 <script lang="ts">
   import type { SvelteHTMLElements } from 'svelte/elements'
 

--- a/src/components/navdots/navdots.svelte
+++ b/src/components/navdots/navdots.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="leo-navdots" />
-
 <script lang="ts">
   import { createEventDispatcher } from 'svelte'
 

--- a/src/components/progress/progressBar.svelte
+++ b/src/components/progress/progressBar.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="leo-progressbar" />
-
 <script lang="ts">
   export let progress: number = 0
 </script>

--- a/src/components/progress/progressRing.svelte
+++ b/src/components/progress/progressRing.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="leo-progressring" />
-
 <script lang="ts">
   export let progress = 0
   export let mode: 'determinate' | 'indeterminate' = 'indeterminate'

--- a/src/components/svelte-react.ts
+++ b/src/components/svelte-react.ts
@@ -4,43 +4,14 @@ import {
   useEffect,
   forwardRef,
   useCallback,
-  useMemo,
   type ForwardedRef,
   type PropsWithChildren
 } from 'react'
-import type { SvelteComponent, SvelteComponentTyped } from 'svelte'
+import type { SvelteComponentTyped } from 'svelte'
 
 const eventRegex = /on([A-Z]{1,}[a-zA-Z]*)/
-const watchRegex = /watch([A-Z]{1,}[a-zA-Z]*)/
 
-// TODO(petemill):
-// When web-components are supported in react (currently only in experimental version), then we can
-// directly use the web-component and define it's availability as a global jsx element,
-// avoiding `SvelteWebComponentToReact`, via:
-//
-// type CustomElement<T> = Partial<T & React.DOMAttributes<T> & { children: any }>
-//
-// declare global {
-//   namespace JSX {
-//     interface IntrinsicElements {
-//       ['leo-button']: CustomElement<Props>
-//     }
-//   }
-// }
-
-// Other props we could include here are:
-// dir, lang, translate, autocapitalize, contenteditable, contextmenu, data-*, draggable, itemprop, spellcheck, title
-// https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes
-export const intrinsicProps = [
-  'className',
-  'id',
-  'hidden',
-  'role',
-  'style',
-  'tabIndex'
-] as const
-export const intrinsicPropsSet = new Set<string>(intrinsicProps)
-export type IntrinsicProps = (typeof intrinsicProps)[number]
+export type IntrinsicProps = 'className' | 'id' | 'hidden' | 'role' | 'style' | 'tabIndex'
 
 export type SvelteProps<T> = T extends SvelteComponentTyped<
   infer Props,
@@ -67,6 +38,43 @@ export type ReactProps<Props, Events> = Props & {
   [P in IntrinsicProps]?: JSX.IntrinsicElements['div'][P]
 }
 
+const useEventHandlers = (el: HTMLElement | undefined, props: any) => {
+  const lastValue = useRef<{ [key: string]: (...args: any[]) => any }>({})
+
+  // Handle updating event listeners when props change
+  useEffect(() => {
+    if (!el) return
+    for (const [key, listener] of Object.entries(props) as [string, (...args: any[]) => any][]) {
+      const match = eventRegex.exec(key);
+      if (!match) continue
+
+      const event = match[1].toLowerCase()
+      const oldListener = lastValue.current[event]
+      if (listener === oldListener) continue
+
+      if (oldListener) el.removeEventListener(event, oldListener)
+      el.addEventListener(event, listener)
+
+      // Keep track of the last value, so we're able to add/remove it.
+      lastValue.current[event] = listener
+    }
+
+    // Remove any listeners which are no longer present
+    for (const removed of Object.keys(lastValue).filter(k => !props[`on${k}`])) {
+      el.removeEventListener(removed, lastValue.current[removed])
+      delete lastValue.current[removed]
+    }
+  }, [props])
+
+  // Handle cleaning up event listeners when destroying component
+  useEffect(() => () => {
+    if (!el) return
+    for (const [event, listener] of Object.entries(lastValue.current)) {
+      el.removeEventListener(event, listener)
+    } 
+  }, [])
+}
+
 /**
  *
  * @param tag custom element tag name for svelte component
@@ -75,128 +83,43 @@ export type ReactProps<Props, Events> = Props & {
  */
 export default function SvelteWebComponentToReact<
   T extends Record<string, any>
->(tag: string, component: typeof SvelteComponent) {
+>(tag: string, component: typeof HTMLElement) {
   return forwardRef(
     (
       props: PropsWithChildren<T>,
-      forwardedRef: ForwardedRef<SvelteComponent>
+      forwardedRef: ForwardedRef<HTMLElement>
     ) => {
-      const component = useRef<SvelteComponent>()
+      const component = useRef<HTMLElement>()
 
-      const setRef = useCallback((ref: SvelteComponent) => {
+      const setRef = useCallback((ref: HTMLElement) => {
         if (!ref) {
           console.error('No component for tag', tag)
           return
         }
-        if (component.current) {
-          console.warn(
-            'Component replaced, this should not be common',
-            tag,
-            component.current,
-            ref
-          )
-          component.current.$destroy()
-        }
-        // Make sure we actually made a svelte component. This can
-        // go wrong if the custom-element tag name is changed.
-        if (!ref.$on) {
-          console.error(
-            `Creating element with tag name "${tag}" did not result in a Svelte component! Please make sure the tag name is correct and the component code is included on the page.`
-          )
-          return
-        }
+
         component.current = ref
         if (forwardedRef) {
           if (typeof forwardedRef === 'function') forwardedRef(ref)
           else forwardedRef.current = ref
         }
-
-        // Events fire callbacks when the event is dispatched
-        // from the svelte component.
-        // Watchers fire callbacks when the variable (aka property or attribute)
-        // of the svelte component is changed.
-        const watchers: [string, Function][] = []
-        for (const key in props) {
-          if (typeof props[key] !== 'function') {
-            continue
-          }
-          const eventHandler: (event: any) => void = props[key]
-          // It's either an event or a watch
-          const eventMatch = key.match(eventRegex)
-          if (eventMatch) {
-            ref.$on(
-              `${eventMatch[1][0].toLowerCase()}${eventMatch[1].slice(1)}`,
-              eventHandler
-            )
-            continue
-          }
-          const watchMatch = key.match(watchRegex)
-          if (watchMatch) {
-            watchers.push([
-              `${watchMatch[1][0].toLowerCase()}${watchMatch[1].slice(1)}`,
-              eventHandler
-            ])
-          }
-        }
-
-        if (watchers.length) {
-          const update = component.current.$$.update
-          component.current.$$.update = function (...updateArgs) {
-            watchers.forEach(([name, callback]) => {
-              if (component.current) {
-                const index = component.current.$$.props[name]
-                callback((component.current.$$.ctx as any)[index])
-              }
-            })
-            update.apply(null, updateArgs)
-          }
-        }
       }, [])
 
+      useEventHandlers(component.current, props)
+
       useEffect(() => {
+        if (!component.current) return
         // Create a dictionary of all our properties without events. If we pass an
         // onClick prop through to Svelte, we could inadvertently set it on the
         // HTMLElement if we use <el {...$restProps}/>, which causes a Svelte to
         // setAttribute('onClick', props['onClick']). This can lead to unexpected
         // behavior, and triggers a TrustedTypes error.
-        const componentProps = { ...props }
-        for (const reserved of Object.keys(props)
-          // Filter out events & intrinsicProps - these are handled specially
-          .filter(
-            (name) => eventRegex.test(name) || intrinsicPropsSet.has(name)
-          )) {
-          delete componentProps[reserved]
+        for (const [key, value] of Object.entries(props)) {
+          if (eventRegex.test(key) || key === 'children') continue
+          (component.current as any)[key] = value;
         }
-
-        if (component.current) {
-          component.current.$set(componentProps)
-        }
-      }, [props])
-
-      useEffect(() => {
-        return () => {
-          if (component.current) {
-            // component.current.$destroy()
-          }
-        }
-      }, [])
-
-      // All intrinsic props are passed directly to the web component, rather than
-      // being set on the underlying Svelte component.
-      const wcProps = useMemo(() => {
-        const result: any = {}
-        for (const key of intrinsicProps) {
-          if (!(key in props)) continue
-          // Note: React doesn't handle properties called |class| properly.
-          // Special casing this in Leo is fine because it makes things more
-          // consistent with the rest of the React ecosystem.
-          result[key === 'className' ? 'class' : key] = props[key]
-        }
-        return result
       }, [props])
 
       return createElement(tag, {
-        ...wcProps,
         ref: setRef,
         children: props.children
       })

--- a/src/components/svelte-react.ts
+++ b/src/components/svelte-react.ts
@@ -46,7 +46,7 @@ export type ReactProps<Props, Events> = Props & {
 }
 
 const useEventHandlers = (props: any) => {
-  const [el, setEl] = useState<HTMLElement>(null)
+  const [el, setEl] = useState<HTMLElement>()
   const lastValue = useRef<{ [key: string]: (...args: any[]) => any }>({})
 
   // Handle updating event listeners when props change
@@ -79,12 +79,14 @@ const useEventHandlers = (props: any) => {
     }
   }, [props, el])
 
-  const setElement = useCallback((el: HTMLElement | null) => {
+  const setElement = useCallback((el: HTMLElement | undefined) => {
     lastValue.current = {}
     setEl((oldValue) => {
-      // Cleanup
-      for (const [event, listener] of Object.entries(lastValue.current)) {
-        oldValue.removeEventListener(event, listener)
+      if (oldValue) {
+        // Cleanup
+        for (const [event, listener] of Object.entries(lastValue.current)) {
+          oldValue.removeEventListener(event, listener)
+        }
       }
       return el
     })

--- a/src/components/svelte-react.ts
+++ b/src/components/svelte-react.ts
@@ -12,7 +12,13 @@ import type { SvelteComponentTyped } from 'svelte'
 
 const eventRegex = /on([A-Z]{1,}[a-zA-Z]*)/
 
-export type IntrinsicProps = 'className' | 'id' | 'hidden' | 'role' | 'style' | 'tabIndex'
+export type IntrinsicProps =
+  | 'className'
+  | 'id'
+  | 'hidden'
+  | 'role'
+  | 'style'
+  | 'tabIndex'
 
 export type SvelteProps<T> = T extends SvelteComponentTyped<
   infer Props,
@@ -33,11 +39,11 @@ export type ReactProps<Props, Events> = Props & {
 } & {
   ref?: ForwardedRef<Partial<Props & HTMLElement> | undefined>
 } & {
-    // Note: The div here isn't important because all props in intrinsicProps are
-    // available on all elements. We just want to make sure we have the correct
-    // React name/value for them.
-    [P in IntrinsicProps]?: JSX.IntrinsicElements['div'][P]
-  }
+  // Note: The div here isn't important because all props in intrinsicProps are
+  // available on all elements. We just want to make sure we have the correct
+  // React name/value for them.
+  [P in IntrinsicProps]?: JSX.IntrinsicElements['div'][P]
+}
 
 const useEventHandlers = (props: any) => {
   const [el, setEl] = useState<HTMLElement>(null)
@@ -46,8 +52,11 @@ const useEventHandlers = (props: any) => {
   // Handle updating event listeners when props change
   useEffect(() => {
     if (!el) return
-    for (const [key, listener] of Object.entries(props) as [string, (...args: any[]) => any][]) {
-      const match = eventRegex.exec(key);
+    for (const [key, listener] of Object.entries(props) as [
+      string,
+      (...args: any[]) => any
+    ][]) {
+      const match = eventRegex.exec(key)
       if (!match) continue
 
       const event = match[1].toLowerCase()
@@ -62,7 +71,9 @@ const useEventHandlers = (props: any) => {
     }
 
     // Remove any listeners which are no longer present
-    for (const removed of Object.keys(lastValue).filter(k => !props[`on${k}`])) {
+    for (const removed of Object.keys(lastValue).filter(
+      (k) => !props[`on${k}`]
+    )) {
       el.removeEventListener(removed, lastValue.current[removed])
       delete lastValue.current[removed]
     }
@@ -70,7 +81,7 @@ const useEventHandlers = (props: any) => {
 
   const setElement = useCallback((el: HTMLElement | null) => {
     lastValue.current = {}
-    setEl(oldValue => {
+    setEl((oldValue) => {
       // Cleanup
       for (const [event, listener] of Object.entries(lastValue.current)) {
         oldValue.removeEventListener(event, listener)
@@ -94,27 +105,27 @@ export default function SvelteWebComponentToReact<
   T extends Record<string, any>
 >(tag: string, component: typeof HTMLElement) {
   return forwardRef(
-    (
-      props: PropsWithChildren<T>,
-      forwardedRef: ForwardedRef<HTMLElement>
-    ) => {
+    (props: PropsWithChildren<T>, forwardedRef: ForwardedRef<HTMLElement>) => {
       const component = useRef<HTMLElement>()
       const { setElement } = useEventHandlers(props)
 
-      const setRef = useCallback((ref: HTMLElement) => {
-        setElement(ref)
+      const setRef = useCallback(
+        (ref: HTMLElement) => {
+          setElement(ref)
 
-        if (!ref) {
-          console.error('No component for tag', tag)
-          return
-        }
+          if (!ref) {
+            console.error('No component for tag', tag)
+            return
+          }
 
-        component.current = ref
-        if (forwardedRef) {
-          if (typeof forwardedRef === 'function') forwardedRef(ref)
-          else forwardedRef.current = ref
-        }
-      }, [setElement])
+          component.current = ref
+          if (forwardedRef) {
+            if (typeof forwardedRef === 'function') forwardedRef(ref)
+            else forwardedRef.current = ref
+          }
+        },
+        [setElement]
+      )
 
       useEffect(() => {
         if (!component.current) return
@@ -125,7 +136,7 @@ export default function SvelteWebComponentToReact<
         // behavior, and triggers a TrustedTypes error.
         for (const [key, value] of Object.entries(props)) {
           if (eventRegex.test(key) || key === 'children') continue
-          (component.current as any)[key] = value;
+          ;(component.current as any)[key] = value
         }
       }, [props])
 

--- a/src/components/svelte-web.ts
+++ b/src/components/svelte-web.ts
@@ -1,191 +1,199 @@
 import type { SvelteComponent } from 'svelte'
 
 interface Options {
-    mode: 'open' | 'closed'
-    name: string
-    attributes: string
+  mode: 'open' | 'closed'
+  name: string
 }
 
-const reflectToAttributes = new Set([
-    'string',
-    'number',
-    'boolean'
-])
+const reflectToAttributes = new Set(['string', 'number', 'boolean'])
 
 const createSlot = (name?: string) => {
-    let slot: HTMLElement;
-    return {
-        // Create
-        c() {
-            slot = document.createElement("slot");
-            if (name) {
-                slot.setAttribute('name', name)
-            }
-        },
+  let slot: HTMLElement
+  return {
+    // Create
+    c() {
+      slot = document.createElement('slot')
+      if (name) {
+        slot.setAttribute('name', name)
+      }
+    },
 
-        // Mount
-        m(target, anchor) {
-            target.insertBefore(slot, anchor || null);
-        },
+    // Mount
+    m(target, anchor) {
+      target.insertBefore(slot, anchor || null)
+    },
 
-        // Props changed
-        p() {},
+    // Props changed
+    p() {},
 
-        // Detach
-        d(detaching) {
-            if (detaching && slot.parentNode) {
-                slot.parentNode.removeChild(slot);
-            }
-        }
+    // Detach
+    d(detaching) {
+      if (detaching && slot.parentNode) {
+        slot.parentNode.removeChild(slot)
+      }
     }
+  }
 }
 
-export default function registerWebComponent(component: any, { name, mode }: Options) {
-    // Create & mount a dummy component. We use this to work out what props are
-    // available and generate a list of available properties.
-    const c = new component({ target: document.createElement('div') })
+export default function registerWebComponent(
+  component: any,
+  { name, mode }: Options
+) {
+  // Create & mount a dummy component. We use this to work out what props are
+  // available and generate a list of available properties.
+  const c = new component({ target: document.createElement('div') })
 
-    // The names of all properties on our Svelte component.
-    const props = Object.keys(c.$$.props)
+  // The names of all properties on our Svelte component.
+  const props = Object.keys(c.$$.props)
 
-    // A mapping of 'attributename' to 'propertyName', as attributes are
-    // lowercase, while Svelte components are generally 'camelCase'.
-    const attributePropMap = props.reduce((prev, next) => {
-        prev.set(next.toLowerCase(), next);
-        return prev
-    }, new Map<string, string>());
+  // A mapping of 'attributename' to 'propertyName', as attributes are
+  // lowercase, while Svelte components are generally 'camelCase'.
+  const attributePropMap = props.reduce((prev, next) => {
+    prev.set(next.toLowerCase(), next)
+    return prev
+  }, new Map<string, string>())
 
-    // Note attribute keys, so changes cause us to update our Svelte Component.
-    const attributes = Array.from(attributePropMap.keys())
+  // Note attribute keys, so changes cause us to update our Svelte Component.
+  const attributes = Array.from(attributePropMap.keys())
 
-    class SvelteWrapper extends HTMLElement {
-        component: SvelteComponent
+  class SvelteWrapper extends HTMLElement {
+    component: SvelteComponent
 
-        static get observedAttributes() {
-            return attributes;
-        }
-
-        constructor() {
-            super()
-
-            // Mount shadow - this is where we're going to render our Component.
-            const shadow = this.attachShadow({ mode })
-
-            let lastSlots = new Set()
-            const updateSlots = () => {
-                const slotsNames = Array.from(this.children).map(c => c.getAttribute('slot'))
-                // Add default slot
-                if (this.childNodes.length) slotsNames.push(undefined);
-
-                // Slots didn't change, so nothing to do here.
-                // The component needs to get created, at least once
-                if (this.component 
-                    // If the size is the same, and every one of our last slots
-                    // is present, then nothing has changed, and we don't need
-                    // to do anything here.
-                    && lastSlots.size === slotsNames.length 
-                    && slotsNames.every(s => lastSlots.has(s))) {
-                    return
-                }
-
-                // Update the last slots we have, so if they change we know to update them.
-                lastSlots = new Set(slotsNames);
-
-                // Create a dictionary of the slotName: <slot name={slotName}/>
-                const slots = slotsNames
-                    .reduce((prev, next) => ({ ...prev, [next ?? 'default']: [() => createSlot(next)] }), {})
-
-                // If we've already created the component, we might have some
-                // existing props. We need to create a snapshot of the component
-                // so we can recreate it as faithfully as possible.
-                // Note: We might be able to do some additional hackery here
-                // to copy over even more information from $$.ctx and exactly
-                // maintain the component state!
-                const existingProps = Object.keys(this.component?.$$.props ?? {})
-                    .map(k => [k, this[k]]).reduce((prev, [key, value]) => ({ ...prev, [key]: value }), {});
-
-                // If the component already exists, destroy it. This is,
-                // unfortunately, necessary as there is no way to update slotted
-                // content in the output Svelte compiles to. This is a problem
-                // even when not doing crazy things:
-                // https://github.com/sveltejs/svelte/issues/5312
-                if (this.component) {
-                    this.component.$destroy();
-                }
-
-                // Finally, we actually create the component
-                this.component = new component({
-                    // Target this shadowDOM, so we get nicely encapsulated
-                    // styles
-                    target: shadow,
-                    props: {
-                        // Copy over existing props (there might be none, if
-                        // this is our first render).
-                        ...existingProps,
-                        // Create WebComponent slots for each Svelte slot we
-                        // have content for. This has to be done at render or
-                        // Svelte won't support fallback content.
-                        $$slots: slots,
-                        // Not sure what this is needed for but Svelte crashes
-                        // without it. I think this might be related to slot
-                        // props:
-                        // https://svelte.dev/tutorial/slot-props
-                        $$scope: { ctx: [] }
-                    }
-                })
-            }
-
-            // Unfortunately we need a DOMMutationObserver to let us know when
-            // slotted content changes because we dynamically create & remove
-            // slots. This is for two reasons:
-            // 1) At runtime, we don't know what slots our Svelte component has
-            // 2) Even if we did, if we generated all of the slots at mount time
-            //    then Svelte would never render any of the fallback content,
-            //    event if the slot was empty.
-            new MutationObserver(updateSlots).observe(this, {
-                childList: true,
-                attributes: false,
-                attributeOldValue: false,
-                subtree: false,
-                characterData: false,
-                characterDataOldValue: false,
-            })
-
-            // Update slots on create.
-            updateSlots()
-
-            // For some reason setting this on |SvelteWrapper| doesn't work properly.
-            for (const prop of props) {
-                Object.defineProperty(this, prop, {
-                    enumerable: true,
-                    get() {
-                        const contextIndex = c.$$.props[prop]
-                        return this.component.$$.ctx[contextIndex]
-                    },
-                    set(value) {
-                        if (reflectToAttributes.has(typeof value)) {
-                            this.setAttribute(prop, value)
-                        }
-                        this.component.$$set({ [prop]: value })
-                    }
-                })
-            }
-        }
-
-        attributeChangedCallback(name, oldValue, newValue) {
-            if (oldValue === newValue) return
-            this[name] = newValue
-        }
-
-        addEventListener(event: string, callback: (...args) => void, options: any) {
-            this.component.$on(event, callback)
-
-            // TODO: We could do this but we don't know if the event is handled
-            // by the component or not so we could end up triggering the event
-            // twice (i.e. in the case of 'click')
-            // super.addEventListener(event, callback, options)
-        }
+    static get observedAttributes() {
+      return attributes
     }
 
-    customElements.define(name, SvelteWrapper)
+    constructor() {
+      super()
+
+      // Mount shadow - this is where we're going to render our Component.
+      const shadow = this.attachShadow({ mode })
+
+      let lastSlots = new Set()
+      const updateSlots = () => {
+        const slotsNames = Array.from(this.children).map((c) =>
+          c.getAttribute('slot')
+        )
+        // Add default slot
+        if (this.childNodes.length) slotsNames.push(undefined)
+
+        // Slots didn't change, so nothing to do here.
+        // The component needs to get created, at least once
+        if (
+          this.component &&
+          // If the size is the same, and every one of our last slots
+          // is present, then nothing has changed, and we don't need
+          // to do anything here.
+          lastSlots.size === slotsNames.length &&
+          slotsNames.every((s) => lastSlots.has(s))
+        ) {
+          return
+        }
+
+        // Update the last slots we have, so if they change we know to update them.
+        lastSlots = new Set(slotsNames)
+
+        // Create a dictionary of the slotName: <slot name={slotName}/>
+        const slots = slotsNames.reduce(
+          (prev, next) => ({
+            ...prev,
+            [next ?? 'default']: [() => createSlot(next)]
+          }),
+          {}
+        )
+
+        // If we've already created the component, we might have some
+        // existing props. We need to create a snapshot of the component
+        // so we can recreate it as faithfully as possible.
+        // Note: We might be able to do some additional hackery here
+        // to copy over even more information from $$.ctx and exactly
+        // maintain the component state!
+        const existingProps = Object.keys(this.component?.$$.props ?? {})
+          .map((k) => [k, this[k]])
+          .reduce((prev, [key, value]) => ({ ...prev, [key]: value }), {})
+
+        // If the component already exists, destroy it. This is,
+        // unfortunately, necessary as there is no way to update slotted
+        // content in the output Svelte compiles to. This is a problem
+        // even when not doing crazy things:
+        // https://github.com/sveltejs/svelte/issues/5312
+        if (this.component) {
+          this.component.$destroy()
+        }
+
+        // Finally, we actually create the component
+        this.component = new component({
+          // Target this shadowDOM, so we get nicely encapsulated
+          // styles
+          target: shadow,
+          props: {
+            // Copy over existing props (there might be none, if
+            // this is our first render).
+            ...existingProps,
+            // Create WebComponent slots for each Svelte slot we
+            // have content for. This has to be done at render or
+            // Svelte won't support fallback content.
+            $$slots: slots,
+            // Not sure what this is needed for but Svelte crashes
+            // without it. I think this might be related to slot
+            // props:
+            // https://svelte.dev/tutorial/slot-props
+            $$scope: { ctx: [] }
+          }
+        })
+      }
+
+      // Unfortunately we need a DOMMutationObserver to let us know when
+      // slotted content changes because we dynamically create & remove
+      // slots. This is for two reasons:
+      // 1) At runtime, we don't know what slots our Svelte component has
+      // 2) Even if we did, if we generated all of the slots at mount time
+      //    then Svelte would never render any of the fallback content,
+      //    event if the slot was empty.
+      new MutationObserver(updateSlots).observe(this, {
+        childList: true,
+        attributes: false,
+        attributeOldValue: false,
+        subtree: false,
+        characterData: false,
+        characterDataOldValue: false
+      })
+
+      // Update slots on create.
+      updateSlots()
+
+      // For some reason setting this on |SvelteWrapper| doesn't work properly.
+      for (const prop of props) {
+        Object.defineProperty(this, prop, {
+          enumerable: true,
+          get() {
+            const contextIndex = c.$$.props[prop]
+            return this.component.$$.ctx[contextIndex]
+          },
+          set(value) {
+            if (reflectToAttributes.has(typeof value)) {
+              this.setAttribute(prop, value)
+            }
+            this.component.$$set({ [prop]: value })
+          }
+        })
+      }
+    }
+
+    attributeChangedCallback(name, oldValue, newValue) {
+      if (oldValue === newValue) return
+      this[name] = newValue
+    }
+
+    addEventListener(event: string, callback: (...args) => void, options: any) {
+      this.component.$on(event, callback)
+
+      // TODO: We could do this but we don't know if the event is handled
+      // by the component or not so we could end up triggering the event
+      // twice (i.e. in the case of 'click')
+      // super.addEventListener(event, callback, options)
+    }
+  }
+
+  customElements.define(name, SvelteWrapper)
 }

--- a/src/components/svelte-web.ts
+++ b/src/components/svelte-web.ts
@@ -1,3 +1,5 @@
+import type { SvelteComponent } from 'svelte'
+
 interface Options {
     mode: 'open' | 'closed'
     name: string
@@ -5,14 +7,43 @@ interface Options {
 }
 
 export default function registerWebComponent(component: ConstructorOfATypedSvelteComponent, { name, mode }: Options) {
+    const c = new component({ target: document.createElement('div') }) as any
+    const props = Object.keys(c.$$.props)
+    const attributePropMap = new Map<string, string>();
+    for (const prop of props) {
+        attributePropMap.set(prop.toLowerCase(), prop);
+    }
+    const attributes = Array.from(attributePropMap.keys())
+
     class SvelteWrapper extends HTMLElement {
+        component: SvelteComponent
+
+        static get observedAttributes() {
+            return attributes;
+        }
+
         constructor() {
             super()
 
             const shadow = this.attachShadow({ mode })
-            new component({
+            this.component = new component({
                 target: shadow
-            })
+            }) as any
+
+            // console.log(name, component)
+        }
+
+        attributeChangedCallback(name, oldValue, newValue) {
+            console.log(name, oldValue, newValue);
+            (this.component as any).$$set({ [attributePropMap.get(name)]: newValue })
+        }
+
+        connectedCallback() {
+            console.log('connected')
+        }
+
+        disconnectedCallback() {
+            console.log('disconnected')
         }
     }
 

--- a/src/components/svelte-web.ts
+++ b/src/components/svelte-web.ts
@@ -39,7 +39,6 @@ const createSlot = (name?: string) => {
         }
     }
 }
-window['createSlot'] = createSlot
 
 export default function registerWebComponent(component: any, { name, mode }: Options) {
     // Create & mount a dummy component. We use this to work out what props are

--- a/src/components/svelte-web.ts
+++ b/src/components/svelte-web.ts
@@ -25,6 +25,7 @@ const createSlot = (name?: string) => {
             target.insertBefore(slot, anchor || null);
         },
         p(ctx, dirty) {
+            console.log("Updated slot", ctx, dirty)
             // if (dirty & /*isOpen*/ 2 && t_value !== (t_value = (/*isOpen*/ ctx[1] ? 'open' : 'closed') + "")) set_data(t, t_value);
         },
         d(detaching) {
@@ -34,6 +35,7 @@ const createSlot = (name?: string) => {
         }
     }
 }
+window['createSlot'] = createSlot
 
 export default function registerWebComponent(component: any, { name, mode }: Options) {
     const c = new component({ target: document.createElement('div') }) as any
@@ -60,7 +62,7 @@ export default function registerWebComponent(component: any, { name, mode }: Opt
                 target: shadow,
                 props: {
                     $$slots: {
-                        default: [() => node]
+                        // default: [() => node]
                     },
                     $$scope: { ctx: [] }
                 }
@@ -82,6 +84,31 @@ export default function registerWebComponent(component: any, { name, mode }: Opt
                     }
                 })
             }
+
+            // for (const slot of shadow.querySelectorAll('slot')) {
+            //     slot.addEventListener('slotchange', this.onSlotChanged)
+            // }
+
+            const updateSlots = () => {
+                const slotsNames = Array.from(this.children).map(c => c.getAttribute('slot'))
+                // Add default slot
+                if (this.childNodes.length) slotsNames.push('');
+                const slots = slotsNames
+                    .reduce((prev, next) => ({ ...prev, [next]: [createSlot(next)] }), {})
+                console.log("Found slots:", Object.keys(slots))
+                this.component.$$set({ $$slots: slots })
+            }
+            new MutationObserver(updateSlots).observe(this, {
+                childList: true,
+                attributes: false,
+                attributeOldValue: false,
+                subtree: false,
+                characterData: false,
+                characterDataOldValue: false,
+            })
+            updateSlots()
+
+            this.component.$$.bound[9] = console.log
         }
 
         attributeChangedCallback(name, oldValue, newValue) {
@@ -96,6 +123,10 @@ export default function registerWebComponent(component: any, { name, mode }: Opt
             // by the component or not so we could end up triggering the event
             // twice (i.e. in the case of 'click')
             // super.addEventListener(event, callback, options)
+        }
+
+        onSlotChanged(event: Event) {
+            console.log('slot changed', event.target)
         }
     }
 

--- a/src/components/svelte-web.ts
+++ b/src/components/svelte-web.ts
@@ -6,6 +6,12 @@ interface Options {
     attributes: string
 }
 
+const reflectToAttributes = new Set([
+    'string',
+    'number',
+    'boolean'
+])
+
 export default function registerWebComponent(component: any, { name, mode }: Options) {
     const c = new component({ target: document.createElement('div') }) as any
     const props = Object.keys(c.$$.props)
@@ -39,6 +45,9 @@ export default function registerWebComponent(component: any, { name, mode }: Opt
                         return this.component.$$.ctx[contextIndex]
                     },
                     set(value) {
+                        if (reflectToAttributes.has(typeof value)) {
+                            this.setAttribute(prop, value)
+                        }
                         this.component.$$set({ [prop]: value })
                     }
                 })
@@ -46,8 +55,8 @@ export default function registerWebComponent(component: any, { name, mode }: Opt
         }
 
         attributeChangedCallback(name, oldValue, newValue) {
-            console.log(name, oldValue, newValue);
-            (this.component as any).$$set({ [attributePropMap.get(name)]: newValue })
+            if (oldValue === newValue) return
+            this[name] = newValue
         }
 
         connectedCallback() {

--- a/src/components/svelte-web.ts
+++ b/src/components/svelte-web.ts
@@ -57,8 +57,23 @@ export default function registerWebComponent(
   const attributes = Array.from(attributePropMap.keys())
 
   class SvelteWrapper extends HTMLElement {
-    component: SvelteComponent
     listeners = new Map<string, Map<Function, Function>>()
+    #component: SvelteComponent
+    get component() {
+        return this.#component
+    }
+
+    set component(value) {
+        // We need to make sure that when we recreate the component (as in the
+        // case of slots changing) that we copy over all of the event listeners.
+        this.#component = value
+        for (const [event, listeners] of this.listeners.entries()) {
+            for (const [callback, remove] of listeners.entries()) {
+                remove()
+                this.addEventListener(event, callback)
+            }
+        }
+    }
 
     static get observedAttributes() {
       return attributes

--- a/src/components/svelte-web.ts
+++ b/src/components/svelte-web.ts
@@ -15,19 +15,23 @@ const reflectToAttributes = new Set([
 const createSlot = (name?: string) => {
     let slot: HTMLElement;
     return {
+        // Create
         c() {
             slot = document.createElement("slot");
             if (name) {
                 slot.setAttribute('name', name)
             }
         },
+
+        // Mount
         m(target, anchor) {
             target.insertBefore(slot, anchor || null);
         },
-        p(ctx, dirty) {
-            console.log("Updated slot", ctx, dirty)
-            // if (dirty & /*isOpen*/ 2 && t_value !== (t_value = (/*isOpen*/ ctx[1] ? 'open' : 'closed') + "")) set_data(t, t_value);
-        },
+
+        // Props changed
+        p() {},
+
+        // Detach
         d(detaching) {
             if (detaching && slot.parentNode) {
                 slot.parentNode.removeChild(slot);
@@ -38,12 +42,21 @@ const createSlot = (name?: string) => {
 window['createSlot'] = createSlot
 
 export default function registerWebComponent(component: any, { name, mode }: Options) {
-    const c = new component({ target: document.createElement('div') }) as any
+    // Create & mount a dummy component. We use this to work out what props are
+    // available and generate a list of available properties.
+    const c = new component({ target: document.createElement('div') })
+
+    // The names of all properties on our Svelte component.
     const props = Object.keys(c.$$.props)
-    const attributePropMap = new Map<string, string>();
-    for (const prop of props) {
-        attributePropMap.set(prop.toLowerCase(), prop);
-    }
+
+    // A mapping of 'attributename' to 'propertyName', as attributes are
+    // lowercase, while Svelte components are generally 'camelCase'.
+    const attributePropMap = props.reduce((prev, next) => {
+        prev.set(next.toLowerCase(), next);
+        return prev
+    }, new Map<string, string>());
+
+    // Note attribute keys, so changes cause us to update our Svelte Component.
     const attributes = Array.from(attributePropMap.keys())
 
     class SvelteWrapper extends HTMLElement {
@@ -56,17 +69,91 @@ export default function registerWebComponent(component: any, { name, mode }: Opt
         constructor() {
             super()
 
+            // Mount shadow - this is where we're going to render our Component.
             const shadow = this.attachShadow({ mode })
-            const node = createSlot()
-            this.component = new component({
-                target: shadow,
-                props: {
-                    $$slots: {
-                        // default: [() => node]
-                    },
-                    $$scope: { ctx: [] }
+
+            let lastSlots = new Set()
+            const updateSlots = () => {
+                const slotsNames = Array.from(this.children).map(c => c.getAttribute('slot'))
+                // Add default slot
+                if (this.childNodes.length) slotsNames.push(undefined);
+
+                // Slots didn't change, so nothing to do here.
+                // The component needs to get created, at least once
+                if (this.component 
+                    // If the size is the same, and every one of our last slots
+                    // is present, then nothing has changed, and we don't need
+                    // to do anything here.
+                    && lastSlots.size === slotsNames.length 
+                    && slotsNames.every(s => lastSlots.has(s))) {
+                    return
                 }
+
+                // Update the last slots we have, so if they change we know to update them.
+                lastSlots = new Set(slotsNames);
+
+                // Create a dictionary of the slotName: <slot name={slotName}/>
+                const slots = slotsNames
+                    .reduce((prev, next) => ({ ...prev, [next ?? 'default']: [() => createSlot(next)] }), {})
+
+                // If we've already created the component, we might have some
+                // existing props. We need to create a snapshot of the component
+                // so we can recreate it as faithfully as possible.
+                // Note: We might be able to do some additional hackery here
+                // to copy over even more information from $$.ctx and exactly
+                // maintain the component state!
+                const existingProps = Object.keys(this.component?.$$.props ?? {})
+                    .map(k => [k, this[k]]).reduce((prev, [key, value]) => ({ ...prev, [key]: value }), {});
+
+                // If the component already exists, destroy it. This is,
+                // unfortunately, necessary as there is no way to update slotted
+                // content in the output Svelte compiles to. This is a problem
+                // even when not doing crazy things:
+                // https://github.com/sveltejs/svelte/issues/5312
+                if (this.component) {
+                    this.component.$destroy();
+                }
+
+                // Finally, we actually create the component
+                this.component = new component({
+                    // Target this shadowDOM, so we get nicely encapsulated
+                    // styles
+                    target: shadow,
+                    props: {
+                        // Copy over existing props (there might be none, if
+                        // this is our first render).
+                        ...existingProps,
+                        // Create WebComponent slots for each Svelte slot we
+                        // have content for. This has to be done at render or
+                        // Svelte won't support fallback content.
+                        $$slots: slots,
+                        // Not sure what this is needed for but Svelte crashes
+                        // without it. I think this might be related to slot
+                        // props:
+                        // https://svelte.dev/tutorial/slot-props
+                        $$scope: { ctx: [] }
+                    }
+                })
+            }
+
+            // Unfortunately we need a DOMMutationObserver to let us know when
+            // slotted content changes because we dynamically create & remove
+            // slots. This is for two reasons:
+            // 1) At runtime, we don't know what slots our Svelte component has
+            // 2) Even if we did, if we generated all of the slots at mount time
+            //    then Svelte would never render any of the fallback content,
+            //    event if the slot was empty.
+            new MutationObserver(updateSlots).observe(this, {
+                childList: true,
+                attributes: false,
+                attributeOldValue: false,
+                subtree: false,
+                characterData: false,
+                characterDataOldValue: false,
             })
+
+            // Update slots on create.
+            updateSlots()
 
             // For some reason setting this on |SvelteWrapper| doesn't work properly.
             for (const prop of props) {
@@ -84,31 +171,6 @@ export default function registerWebComponent(component: any, { name, mode }: Opt
                     }
                 })
             }
-
-            // for (const slot of shadow.querySelectorAll('slot')) {
-            //     slot.addEventListener('slotchange', this.onSlotChanged)
-            // }
-
-            const updateSlots = () => {
-                const slotsNames = Array.from(this.children).map(c => c.getAttribute('slot'))
-                // Add default slot
-                if (this.childNodes.length) slotsNames.push('');
-                const slots = slotsNames
-                    .reduce((prev, next) => ({ ...prev, [next]: [createSlot(next)] }), {})
-                console.log("Found slots:", Object.keys(slots))
-                this.component.$$set({ $$slots: slots })
-            }
-            new MutationObserver(updateSlots).observe(this, {
-                childList: true,
-                attributes: false,
-                attributeOldValue: false,
-                subtree: false,
-                characterData: false,
-                characterDataOldValue: false,
-            })
-            updateSlots()
-
-            this.component.$$.bound[9] = console.log
         }
 
         attributeChangedCallback(name, oldValue, newValue) {
@@ -123,10 +185,6 @@ export default function registerWebComponent(component: any, { name, mode }: Opt
             // by the component or not so we could end up triggering the event
             // twice (i.e. in the case of 'click')
             // super.addEventListener(event, callback, options)
-        }
-
-        onSlotChanged(event: Event) {
-            console.log('slot changed', event.target)
         }
     }
 

--- a/src/components/svelte-web.ts
+++ b/src/components/svelte-web.ts
@@ -60,19 +60,19 @@ export default function registerWebComponent(
     listeners = new Map<string, Map<Function, Function>>()
     #component: SvelteComponent
     get component() {
-        return this.#component
+      return this.#component
     }
 
     set component(value) {
-        // We need to make sure that when we recreate the component (as in the
-        // case of slots changing) that we copy over all of the event listeners.
-        this.#component = value
-        for (const [event, listeners] of this.listeners.entries()) {
-            for (const [callback, remove] of listeners.entries()) {
-                remove()
-                this.addEventListener(event, callback)
-            }
+      // We need to make sure that when we recreate the component (as in the
+      // case of slots changing) that we copy over all of the event listeners.
+      this.#component = value
+      for (const [event, listeners] of this.listeners.entries()) {
+        for (const [callback, remove] of listeners.entries()) {
+          remove()
+          this.addEventListener(event, callback)
         }
+      }
     }
 
     static get observedAttributes() {
@@ -216,8 +216,8 @@ export default function registerWebComponent(
     }
 
     removeEventListener(event: string, callback: (...args) => void) {
-        this.listeners.get(event)?.get(callback)?.()
-        this.listeners.get(event)?.delete(callback)
+      this.listeners.get(event)?.get(callback)?.()
+      this.listeners.get(event)?.delete(callback)
     }
   }
 

--- a/src/components/svelte-web.ts
+++ b/src/components/svelte-web.ts
@@ -56,8 +56,9 @@ export default function registerWebComponent(
   // Note attribute keys, so changes cause us to update our Svelte Component.
   const attributes = Array.from(attributePropMap.keys())
 
+  type Callback = (...args: any[]) => void
   class SvelteWrapper extends HTMLElement {
-    listeners = new Map<string, Map<Function, Function>>()
+    listeners = new Map<string, Map<Callback, Callback>>()
     #component: SvelteComponent
     get component() {
       return this.#component
@@ -201,7 +202,7 @@ export default function registerWebComponent(
       this[name] = newValue
     }
 
-    addEventListener(event: string, callback: (...args) => void, options: any) {
+    addEventListener(event: string, callback: Callback) {
       if (!this.listeners.has(event)) {
         this.listeners.set(event, new Map())
       }
@@ -215,7 +216,7 @@ export default function registerWebComponent(
       // super.addEventListener(event, callback, options)
     }
 
-    removeEventListener(event: string, callback: (...args) => void) {
+    removeEventListener(event: string, callback: Callback) {
       this.listeners.get(event)?.get(callback)?.()
       this.listeners.get(event)?.delete(callback)
     }

--- a/src/components/svelte-web.ts
+++ b/src/components/svelte-web.ts
@@ -59,12 +59,13 @@ export default function registerWebComponent(component: any, { name, mode }: Opt
             this[name] = newValue
         }
 
-        connectedCallback() {
-            console.log('connected')
-        }
+        addEventListener(event: string, callback: (...args) => void, options: any) {
+            this.component.$on(event, callback)
 
-        disconnectedCallback() {
-            console.log('disconnected')
+            // TODO: We could do this but we don't know if the event is handled
+            // by the component or not so we could end up triggering the event
+            // twice (i.e. in the case of 'click')
+            // super.addEventListener(event, callback, options)
         }
     }
 

--- a/src/components/svelte-web.ts
+++ b/src/components/svelte-web.ts
@@ -1,0 +1,20 @@
+interface Options {
+    mode: 'open' | 'closed'
+    name: string
+    attributes: string
+}
+
+export default function registerWebComponent(component: ConstructorOfATypedSvelteComponent, { name, mode }: Options) {
+    class SvelteWrapper extends HTMLElement {
+        constructor() {
+            super()
+
+            const shadow = this.attachShadow({ mode })
+            new component({
+                target: shadow
+            })
+        }
+    }
+
+    customElements.define(name, SvelteWrapper)
+}

--- a/src/components/toggle/toggle.svelte
+++ b/src/components/toggle/toggle.svelte
@@ -1,5 +1,3 @@
-<svelte:options tag="leo-toggle" />
-
 <script context="module" lang="ts">
   export const sizes = ['small', 'medium'] as const
   export type Sizes = (typeof sizes)[number]

--- a/src/postcss/theme.js
+++ b/src/postcss/theme.js
@@ -155,7 +155,8 @@ module.exports = (options) => {
         const theme = supportedThemes.find((t) => atRule.params.includes(t))
         if (!theme)
           throw new Error(
-            `Encountered unsupported theme ${atRule.params
+            `Encountered unsupported theme ${
+              atRule.params
             }. Allowed themes are ${supportedThemes.join(', ')}`
           )
 
@@ -186,12 +187,8 @@ module.exports = (options) => {
       ]
       let darkSelectors = [`:root${options.darkSelector}`, options.darkSelector]
 
-      lightSelectors = lightSelectors.map((s) =>
-        options.wrapSelector(s)
-      )
-      darkSelectors = darkSelectors.map((s) =>
-        options.wrapSelector(s)
-      )
+      lightSelectors = lightSelectors.map((s) => options.wrapSelector(s))
+      darkSelectors = darkSelectors.map((s) => options.wrapSelector(s))
 
       const lightRule = new Rule({
         selectors: lightSelectors,

--- a/src/postcss/theme.js
+++ b/src/postcss/theme.js
@@ -8,10 +8,6 @@ const getPropertyName = (selector, decl) => {
     .replace(regex, '\\$1')
 }
 
-const wrapInSelector = (wrap, selector) => {
-  return `${wrap}(${selector})`
-}
-
 const splitRule = (rule, selectorToExtract) => {
   // |cloneAfter|, so in an |each| loop, the new rule will be processed.
   const cloned = rule.cloneAfter()
@@ -33,14 +29,15 @@ const splitRule = (rule, selectorToExtract) => {
 
 const defaultOptions = {
   darkSelector: '[data-theme=dark]',
-  lightSelector: '[data-theme=light]'
+  lightSelector: '[data-theme=light]',
+  wrapSelector: (selector) => selector
 }
 
 /**
  * @param {{
  *  darkSelector: string,
  *  lightSelector: string,
- *  wrapIn?: string,
+ *  wrapSelector?: (selector: string) => string,
  * }} options The options for configuring the selectors for darkmode.
  */
 module.exports = (options) => {
@@ -158,8 +155,7 @@ module.exports = (options) => {
         const theme = supportedThemes.find((t) => atRule.params.includes(t))
         if (!theme)
           throw new Error(
-            `Encountered unsupported theme ${
-              atRule.params
+            `Encountered unsupported theme ${atRule.params
             }. Allowed themes are ${supportedThemes.join(', ')}`
           )
 
@@ -190,14 +186,12 @@ module.exports = (options) => {
       ]
       let darkSelectors = [`:root${options.darkSelector}`, options.darkSelector]
 
-      if (options.wrapIn) {
-        lightSelectors = lightSelectors.map((s) =>
-          wrapInSelector(options.wrapIn, s)
-        )
-        darkSelectors = darkSelectors.map((s) =>
-          wrapInSelector(options.wrapIn, s)
-        )
-      }
+      lightSelectors = lightSelectors.map((s) =>
+        options.wrapSelector(s)
+      )
+      darkSelectors = darkSelectors.map((s) =>
+        options.wrapSelector(s)
+      )
 
       const lightRule = new Rule({
         selectors: lightSelectors,

--- a/src/scripts/gen-react-bindings.js
+++ b/src/scripts/gen-react-bindings.js
@@ -6,7 +6,7 @@ const REACT_BINDINGS_DIRECTORY = 'react/'
 fs.mkdir(REACT_BINDINGS_DIRECTORY, { recursive: true })
 
 const COMPONENT_PREFIX = 'leo'
-const SVELTE_REACT_WRAPPER_PATH = '../svelte/svelte-react.js'
+const SVELTE_REACT_WRAPPER_PATH = '../shared/svelte-react.js'
 
 const getComponentGenerics = async (svelteFilePath, componentName) => {
   const relativePath = path.relative('./src/components', svelteFilePath)

--- a/src/scripts/gen-web-bindings.js
+++ b/src/scripts/gen-web-bindings.js
@@ -1,0 +1,62 @@
+const fs = require('fs/promises')
+const path = require('path')
+const { getSvelteFiles } = require('./common')
+
+const WEB_BINDINGS_DIRECTORY = 'web-components/'
+fs.mkdir(WEB_BINDINGS_DIRECTORY, { recursive: true })
+
+const COMPONENT_PREFIX = 'leo'
+const SVELTE_WEB_WRAPPER_PATH = '../shared/svelte-web.js'
+
+const getFileContents = async (svelteFilePath) => {
+  const fileName = path.basename(svelteFilePath)
+  const extension = path.extname(fileName)
+  const fileNameWithoutExtension = fileName.substring(
+    0,
+    fileName.length - extension.length
+  )
+  const componentName =
+    fileNameWithoutExtension[0].toUpperCase() +
+    fileNameWithoutExtension.substring(1)
+
+    const binding = `
+import SvelteWeb from '${SVELTE_WEB_WRAPPER_PATH}'
+import ${componentName} from '../shared/${fileNameWithoutExtension}.js'
+export default SvelteWeb(${componentName}, {
+    name: '${COMPONENT_PREFIX}-${fileNameWithoutExtension.toLowerCase()}',
+    mode: 'open'
+});
+
+// Reexport everything from our component, so consumers can do anything the base
+// component can do.
+export * from '../shared/${fileNameWithoutExtension}.js'
+    `.trim()
+
+  return binding
+}
+
+const createBinding = async (svelteFilePath) => {
+  const filename = path.basename(svelteFilePath, '.svelte')
+
+  const binding = await getFileContents(svelteFilePath)
+  await fs.writeFile(
+    path.join(WEB_BINDINGS_DIRECTORY, `${filename}.js`),
+    binding
+  )
+}
+
+const createBindings = async (rootDir) => {
+  for await (const sveltePath of getSvelteFiles(
+    rootDir,
+    /*includeDts=*/ false
+  )) {
+    console.log(`Creating Web Component Binding for ${sveltePath}`)
+    await createBinding(sveltePath)
+  }
+}
+
+module.exports = createBindings
+
+if (require.main == module) {
+  createBindings('./src/components')
+}

--- a/src/scripts/gen-web-bindings.js
+++ b/src/scripts/gen-web-bindings.js
@@ -19,7 +19,7 @@ const getFileContents = async (svelteFilePath) => {
     fileNameWithoutExtension[0].toUpperCase() +
     fileNameWithoutExtension.substring(1)
 
-    const binding = `
+  const binding = `
 import SvelteWeb from '${SVELTE_WEB_WRAPPER_PATH}'
 import ${componentName} from '../shared/${fileNameWithoutExtension}.js'
 export default SvelteWeb(${componentName}, {

--- a/tests/theme.mixed.test.js
+++ b/tests/theme.mixed.test.js
@@ -238,5 +238,5 @@ it('Handles wrapSelector', () =>
       background: var(--\\.component_background);
       color: var(--\\.component_color);
     }`,
-    { wrapSelector: selector => `:global(${selector})` }
+    { wrapSelector: (selector) => `:global(${selector})` }
   ))

--- a/tests/theme.mixed.test.js
+++ b/tests/theme.mixed.test.js
@@ -197,7 +197,7 @@ it('Light & Dark mode work with weird class overlaps', () =>
     {}
   ))
 
-it('Handles wrapIn', () =>
+it('Handles wrapSelector', () =>
   run(
     `.component {
           padding: 12px;
@@ -238,5 +238,5 @@ it('Handles wrapIn', () =>
       background: var(--\\.component_background);
       color: var(--\\.component_color);
     }`,
-    { wrapIn: ':global' }
+    { wrapSelector: selector => `:global(${selector})` }
   ))


### PR DESCRIPTION
Fix https://github.com/brave/leo/issues/245
Fix https://github.com/brave/leo/issues/244

Unfortunately, this means we need to write our own wrapper. On the bright side, Svelte's web components are **not** well supported and have a number of bugs including:
- Nested component slots conflict with parent component slots
- Nested components styles are not applied

This means we have a bit more room to fix bugs / make changes to how things work. On the other hand, this might make life harder if Svelte changes things down the tracks. We do get a few wins from this:
1. I suspect we'll have a smaller bundle size because more code is shared
2. We can turn child slots on & off! (in Svelte an `{#if false}` is treated as slotted content).
3. We can use advanced Svelte behavior (like bind) inside Leo, although it won't be supported via the web component API. With Svelte's built in Web Components, this does not work.
 
~~This PR is not quite ready yet, as I need to decide how we want the output to look, and I need to do a bit of testing of our React wrapper.~~
- [x] ~~React wrapper testing~~
- [x] ~~Removing event listeners~~