### PR TITLE
The Button, when used as a web component, should be inline-block by default

### DIFF
--- a/src/components/button/button.svelte
+++ b/src/components/button/button.svelte
@@ -79,6 +79,12 @@
 </svelte:element>
 
 <style lang="scss">
+  :host {
+    display: inline-block;
+  }
+  :host button {
+    width: 100%;
+  }
   // Main styles and states
   .leoButton {
     // Gradients cannot have a transition, so we need to reset `transition`


### PR DESCRIPTION
Allowing it to grow inline by default, or be stretched to a specific width via flexbox or a specific width, etc