### PR TITLE
updates renovate schedule config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,5 +9,5 @@
       "enabled": false
     }
   ],
-  "schedule": "at 10:00 am on Sunday"
+  "schedule": ["at 10:00 am on Sunday"]
 }


### PR DESCRIPTION
It appears from [the Renovate docs](https://docs.renovatebot.com/configuration-options/#schedule) that the `schedule` config expects an array.