### PR TITLE
[Bug]: Fix mobile tap highlights

### DIFF
--- a/src/components/button/button.svelte
+++ b/src/components/button/button.svelte
@@ -95,6 +95,7 @@
     --box-shadow-hover: var(--leo-effect-elevation-02);
     display: block;
     cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
     transition: background 0.12s ease-in-out, var(--default-transition);
     box-shadow: none;
     border: solid var(--border-width, 0px) var(--border-color, transparent);

--- a/src/components/collapse/collapse.svelte
+++ b/src/components/collapse/collapse.svelte
@@ -135,6 +135,7 @@
 
     list-style: none;
     cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
 
     color: var(--summary-color);
     transition: color var(--transition-duration) ease-in-out;

--- a/src/components/link/link.svelte
+++ b/src/components/link/link.svelte
@@ -42,6 +42,7 @@
     color: var(--color);
     font: var(--leo-font-text-default-semibold);
     cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
     text-decoration: underline;
 
     &:hover {

--- a/src/components/navdots/navdots.svelte
+++ b/src/components/navdots/navdots.svelte
@@ -99,6 +99,7 @@
     .dot {
       all: unset;
       cursor: pointer;
+      -webkit-tap-highlight-color: transparent;
       margin: var(--dot-vertical-margin) 0;
       width: var(--dot-size);
       height: var(--dot-size);

--- a/src/components/toggle/toggle.svelte
+++ b/src/components/toggle/toggle.svelte
@@ -137,6 +137,8 @@
     align-items: center;
     flex-direction: var(--label-flex-direction);
     gap: var(--label-gap);
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
   }
 
   .leo-toggle button {


### PR DESCRIPTION
Currently on mobile, tapping anything with `cursor: pointer` will result in a nasty blue rectangle on WebKit/Chromium browsers. The solution is to just set `-webkit-tap-highlight-color: transparent` when we set `cursor: pointer`.

Before:
![image](https://user-images.githubusercontent.com/7678024/228709179-c01d0fc1-3129-412b-ade7-ffb027e4e995.png)
![image](https://user-images.githubusercontent.com/7678024/228709224-9c2fa735-3677-4f19-a3dc-73725f9b52bc.png)

After
![image](https://user-images.githubusercontent.com/7678024/228709313-bfd38e19-fa47-4501-90e3-b764e9e864fb.png)
![image](https://user-images.githubusercontent.com/7678024/228709345-6187382d-c5b6-4ab0-a0c4-ea9bd911f879.png)

