### PR TITLE
Add action for auto updating symbols

### DIFF
--- a/.github/workflows/sf-symbols.yml
+++ b/.github/workflows/sf-symbols.yml
@@ -1,0 +1,23 @@
+name: Update SF Symbols
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+
+    steps:
+    - uses: actions/github-script@v6
+      with:
+        github-token: ${{ secrets.LEO_SF_SYMBOLS_ACCESS_TOKEN }}
+        script: |
+          await github.rest.actions.createWorkflowDispatch({
+            owner: 'brave',
+            repo: 'leo-sf-symbols',
+            workflow_id: 'update.yml',
+            ref: 'main'
+          })


### PR DESCRIPTION
@kim0 I've created an action in the Leo SF Symbols repo which I want to run on deploy - would you mind having a look at this and letting me know if you think it's the right approach (and if it is, setting up the `LEO_SF_SYMBOLS_ACCESS_TOKEN` as a token which will let the action get triggered).

I haven't done much with GH Actions before so I might be going in the completely wrong direction. 