### PR TITLE
Make it possible to change the direction of radios/checks

### DIFF
--- a/src/components/checkbox/checkbox.stories.svelte
+++ b/src/components/checkbox/checkbox.stories.svelte
@@ -18,6 +18,11 @@
       type: 'string',
       description: 'The gap between the label and the checkbox'
     },
+    '--leo-checkbox-flex-direction': {
+      control: 'select',
+      description: 'The flex direction of the label/checkbox',
+      options: ['row', 'row-reverse', 'column', 'column-reverse']
+    },
     '--leo-checkbox-checked-color': {
       control: 'color',
       type: 'string',

--- a/src/components/checkbox/checkbox.svelte
+++ b/src/components/checkbox/checkbox.svelte
@@ -64,6 +64,7 @@
   .leo-checkbox {
     --focus-border-radius: var(--leo-checkbox-focus-border-radius, 2px);
     --label-gap: var(--leo-checkbox-label-gap, var(--leo-spacing-8));
+    --flex-direction: var(--leo-checkbox-flex-direction, row);
     --checked-color: var(
       --leo-checkbox-checked-color,
       var(--leo-color-icon-interactive)
@@ -88,7 +89,7 @@
 
     display: flex;
     align-items: center;
-    flex-direction: row;
+    flex-direction: var(--flex-direction);
     gap: var(--label-gap);
     font: var(--font);
     cursor: pointer;

--- a/src/components/radioButton/radioButton.stories.svelte
+++ b/src/components/radioButton/radioButton.stories.svelte
@@ -28,6 +28,11 @@
       type: 'string',
       description: 'The gap between the label and the checkbox'
     },
+    '--leo-radiobutton-flex-direction': {
+      control: 'select',
+      description: 'The flex direction of the label/button',
+      options: ['row', 'row-reverse', 'column', 'column-reverse']
+    },
     '--leo-radiobutton-checked-color': {
       control: 'color',
       type: 'string',

--- a/src/components/radioButton/radioButton.svelte
+++ b/src/components/radioButton/radioButton.svelte
@@ -78,6 +78,7 @@
   .leo-radiobutton {
     --focus-border-radius: var(--leo-radiobutton-focus-border-radius, 2px);
     --label-gap: var(--leo-radiobutton-label-gap, var(--leo-spacing-8));
+    --flex-direction: var(--leo-radiobutton-flex-direction, row);
     --checked-color: var(
       --leo-radiobutton-checked-color,
       var(--leo-color-icon-interactive)
@@ -105,7 +106,7 @@
     --radiobutton-size: var(--leo-radiobutton-radiobutton-size, 20px);
 
     display: flex;
-    flex-direction: row;
+    flex-direction: var(--flex-direction);
     align-items: center;
     gap: var(--label-gap);
     cursor: pointer;


### PR DESCRIPTION
This fixes (partially) https://github.com/brave/leo/issues/261, by making it possible to reverse the direction of the label/checkbox. However, we should definitely think about this some more.

This fixes the issue raised here: https://bravesoftware.slack.com/archives/C03A0MWJXP0/p1681934571717649