### PR TITLE
[Icons]: Fix for reactivity bugs

### DIFF
--- a/src/components/icon/icon.svelte
+++ b/src/components/icon/icon.svelte
@@ -66,6 +66,7 @@
       -webkit-mask-image: var(--icon-url);
       mask-image: var(--icon-url);
       mask-repeat: no-repeat;
+      mask-position: center;
     }
 
     /* Color icons need to be set via a background rather than a mask so we
@@ -73,6 +74,7 @@
     & .icon.color {
       background: var(--icon-url);
       background-repeat: no-repeat;
+      background-position: center;
     }
   }
 </style>

--- a/src/components/icon/icon.svelte
+++ b/src/components/icon/icon.svelte
@@ -1,17 +1,26 @@
 <script context="module" lang="ts">
-  let iconBasePath = '/icons'
-  export const setIconBasePath = (basePath: string) => (iconBasePath = basePath)
+  import { writable } from 'svelte/store'
 
-  const getIconUrl = (name: string) => `${iconBasePath}/${name}.svg`
+  let lastIconBasePath = '/icons'
+  let iconBasePath = writable(lastIconBasePath)
+
+  export const setIconBasePath = (basePath: string) => {
+    lastIconBasePath = basePath
+    iconBasePath.set(basePath)
+  }
+
+  const getIconUrl = (basePath: string, name: string) =>
+    `${basePath}/${name}.svg`
 
   // Not actually used by the component, but used to preload SVGs.
   const svgCache = {}
   export const preloadIcon = (name: string) => {
     const image = new Image()
-    image.src = getIconUrl(name)
+    image.src = getIconUrl(lastIconBasePath, name)
+    image.onerror = () => delete svgCache[image.src]
 
     // Store the image in our cache, so it isn't garbage collected.
-    svgCache[name] = image
+    svgCache[image.src] = image
   }
 </script>
 
@@ -19,7 +28,7 @@
   import type { IconName } from '../../../icons/meta'
   export let name: IconName = undefined
   export let forceColor: boolean = false
-  let hasColor =
+  $: hasColor =
     name?.endsWith('-color') || name?.startsWith('Country=') || forceColor
 </script>
 
@@ -29,7 +38,7 @@
       <div
         class="icon"
         class:color={hasColor}
-        style:--icon-url={`url('${getIconUrl(name)}')`}
+        style:--icon-url={`url('${getIconUrl($iconBasePath, name)}')`}
       />
     {/if}
   </slot>
@@ -39,6 +48,7 @@
   .leoIcon {
     --icon-width: var(--leo-icon-size, 24px);
     --icon-height: var(--leo-icon-size, 24px);
+    --icon-color: var(--leo-icon-color, currentColor);
 
     width: var(--icon-width);
     height: var(--icon-height);
@@ -52,7 +62,7 @@
     /* Non color icons are set via a mask-image, so we can change the color
      * by setting the background */
     & .icon:not(.color) {
-      background: currentColor;
+      background: var(--icon-color);
       -webkit-mask-image: var(--icon-url);
       mask-image: var(--icon-url);
       mask-repeat: no-repeat;

--- a/src/scripts/gen-skia-icons.js
+++ b/src/scripts/gen-skia-icons.js
@@ -16,7 +16,7 @@ fs.mkdir(OUTPUT_FOLDER, { recursive: true })
       const skiaContent = skiafy(svgContent)
       const outputFileName = `leo_${path
         .basename(icon, '.svg')
-        .replace('-', '_')}.icon`
+        .replaceAll('-', '_')}.icon`
       await fs.writeFile(path.join(OUTPUT_FOLDER, outputFileName), skiaContent)
     })
   )


### PR DESCRIPTION
This fixes a few bugs in the icon:
1. The `iconBasePath` is changed after the `Icon` is mounted, which wouldn't trigger a rerender
2. The icon changes from `color` to `non-color`, or vice versa, and the icon wouldn't detect the change.
3. Centre non-square icons (like the flags) so they don't look off