### PR TITLE
[Web Components]: Fix bug where polymer would sometimes remount component

### DIFF
--- a/src/components/svelte-web.ts
+++ b/src/components/svelte-web.ts
@@ -101,7 +101,12 @@ export default function registerWebComponent(
       super()
 
       // Mount shadow - this is where we're going to render our Component.
-      const shadow = this.attachShadow({ mode })
+      // Note: In some rare cases, the shadow root might already exist,
+      // especially when being rendered inside a Polymer dom-if. In this case,
+      // we need to also clear the contents of the node, to ensure we don't
+      // duplicate content.
+      const shadow = this.shadowRoot ?? this.attachShadow({ mode })
+      shadow.replaceChildren()
 
       let lastSlots = new Set()
       const updateSlots = () => {


### PR DESCRIPTION
Interestingly, something Polymer does internally triggers the web component to be reattached to the node. This was the original cause of my issues with the sidebar, and seems to affect Leo too. Fortunately the fix from the Leo end is easy.