### PR TITLE
[Components]: Toggle `on` ==> `checked`

### DIFF
--- a/examples/plain-html/index.html
+++ b/examples/plain-html/index.html
@@ -66,12 +66,12 @@
     const toggled = () => {
       isToggled = !isToggled
 
-      toggle.on = isToggled
+      toggle.checked = isToggled
       collapse.isOpen = isToggled
       toggleButton.textContent = `Open: ${isToggled}`
     }
 
-    toggle.addEventListener('toggle', toggled)
+    toggle.addEventListener('change', toggled)
     toggleButton.addEventListener('click', toggled)
     collapse.addEventListener('toggle', toggled)
     dialogButton.addEventListener('click', () => {

--- a/src/components/toggle/toggle.stories.svelte
+++ b/src/components/toggle/toggle.stories.svelte
@@ -27,7 +27,8 @@
     },
     '--leo-toggle-checked-color-hover': {
       control: 'color',
-      description: 'The background color of the toggle when checked and hovering'
+      description:
+        'The background color of the toggle when checked and hovering'
     },
     '--leo-toggle-unchecked-color': {
       control: 'color',
@@ -35,7 +36,8 @@
     },
     '--leo-toggle-unchecked-color-hover': {
       control: 'color',
-      description: 'The background color of the toggle when not checked and hovering'
+      description:
+        'The background color of the toggle when not checked and hovering'
     },
     '--leo-toggle-thumb-color': {
       control: 'color',

--- a/src/components/toggle/toggle.stories.svelte
+++ b/src/components/toggle/toggle.stories.svelte
@@ -21,21 +21,21 @@
       type: 'string',
       description: 'The padding of the toggle'
     },
-    '--leo-toggle-on-color': {
+    '--leo-toggle-checked-color': {
       control: 'color',
-      description: 'The background color of the toggle when on'
+      description: 'The background color of the toggle when checked'
     },
-    '--leo-toggle-on-color-hover': {
+    '--leo-toggle-checked-color-hover': {
       control: 'color',
-      description: 'The background color of the toggle when on and hovering'
+      description: 'The background color of the toggle when checked and hovering'
     },
-    '--leo-toggle-off-color': {
+    '--leo-toggle-unchecked-color': {
       control: 'color',
-      description: 'The background color of the toggle when off'
+      description: 'The background color of the toggle when not checked'
     },
-    '--leo-toggle-off-color-hover': {
+    '--leo-toggle-unchecked-color-hover': {
       control: 'color',
-      description: 'The background color of the toggle when off and hovering'
+      description: 'The background color of the toggle when not checked and hovering'
     },
     '--leo-toggle-thumb-color': {
       control: 'color',

--- a/src/components/toggle/toggle.stories.svelte
+++ b/src/components/toggle/toggle.stories.svelte
@@ -71,7 +71,7 @@
   <div style={getStyleFromArgs(args)}>
     <Toggle {...args}>
       <div slot="on-icon">
-        <Icon name="check-normal" />
+        <Icon name="cookie" />
       </div>
       {args.label}
     </Toggle>

--- a/src/components/toggle/toggle.svelte
+++ b/src/components/toggle/toggle.svelte
@@ -102,17 +102,17 @@
     --width: var(--leo-toggle-width, 56px);
     --height: var(--leo-toggle-height, 32px);
     --padding: var(--leo-toggle-padding, 2px);
-    --on-color: var(
-      --leo-toggle-on-color,
+    --checked-color: var(
+      --leo-toggle-checked-color,
       var(--leo-color-interaction-button-primary-background)
     );
-    --on-color-hover: var(
-      --leo-toggle-on-color-hover,
+    --checked-color-hover: var(
+      --leo-toggle-checked-color-hover,
       var(--leo-color-primary-60)
     );
-    --off-color: var(--leo-toggle-off-color, var(--leo-color-gray-30));
-    --off-color-hover: var(
-      --leo-toggle-off-color-hover,
+    --unchecked-color: var(--leo-toggle-unchecked-color, var(--leo-color-gray-30));
+    --unchecked-color-hover: var(
+      --leo-toggle-unchecked-color-hover,
       var(--leo-color-gray-40)
     );
     --thumb-color: var(--leo-toggle-thumb-color, var(--leo-color-white));
@@ -126,8 +126,8 @@
     }
 
     @theme (dark) {
-      --on-color-hover: var(
-        --leo-toggle-on-color-hover,
+      --checked-color-hover: var(
+        --leo-toggle-checked-color-hover,
         var(--leo-color-primary-40)
       );
       --thumb-disabled-color: var(--leo-toggle-thumb-disabled-color, black);
@@ -143,7 +143,7 @@
 
   .leo-toggle button {
     all: unset;
-    background: var(--off-color);
+    background: var(--unchecked-color);
     width: var(--width);
     height: var(--height);
     border-radius: var(--leo-radius-full);
@@ -165,24 +165,24 @@
     }
 
     &:hover:not(:disabled) {
-      background-color: var(--off-color-hover);
+      background-color: var(--unchecked-color-hover);
 
       &[aria-checked='true'] {
-        background-color: var(--on-color-hover);
+        background-color: var(--checked-color-hover);
       }
     }
 
     & .thumb {
-      --off-thumb-offset: 0px;
-      --on-thumb-offset: calc(var(--width) - var(--height) + 0.25px);
-      --thumb-offset: var(--off-thumb-offset);
+      --unchecked-thumb-offset: 0px;
+      --checked-thumb-offset: calc(var(--width) - var(--height) + 0.25px);
+      --thumb-offset: var(--unchecked-thumb-offset);
       --drag-offset: 0;
       --thumb-position: max(
         min(
-          var(--on-thumb-offset),
+          var(--checked-thumb-offset),
           calc(var(--thumb-offset) + var(--drag-offset))
         ),
-        var(--off-thumb-offset)
+        var(--unchecked-thumb-offset)
       );
 
       height: 100%;
@@ -211,11 +211,11 @@
     }
 
     &[aria-checked='true'] {
-      background: var(--on-color);
+      background: var(--checked-color);
 
       .thumb {
-        --thumb-offset: var(--on-thumb-offset);
-        color: var(--on-color);
+        --thumb-offset: var(--checked-thumb-offset);
+        color: var(--checked-color);
 
         .on-icon {
           opacity: 1;

--- a/src/components/toggle/toggle.svelte
+++ b/src/components/toggle/toggle.svelte
@@ -8,7 +8,7 @@
 <script lang="ts">
   import { createEventDispatcher } from 'svelte'
 
-  export let on: boolean = false
+  export let checked: boolean = false
   export let disabled: boolean = false
   export let size: Sizes = 'medium'
 
@@ -19,10 +19,10 @@
   let dragOffsetX: number = 0
 
   const dispatch = createEventDispatcher()
-  const toggle = (newValue?: boolean) => {
-    if (newValue === undefined) newValue = !on
-    on = newValue
-    dispatch('toggle', { on })
+  const onChange = (newValue?: boolean) => {
+    if (newValue === undefined) newValue = !checked
+    checked = newValue
+    dispatch('change', { checked })
   }
 </script>
 
@@ -33,10 +33,10 @@
 
     // If we didn't drag just toggle the state.
     if (dragOffsetX === 0) {
-      toggle()
+      onChange()
     } else {
-      if (dragOffsetX > DRAG_AMOUNT_TO_CHANGE && !on) toggle(true)
-      if (dragOffsetX < -DRAG_AMOUNT_TO_CHANGE && on) toggle(false)
+      if (dragOffsetX > DRAG_AMOUNT_TO_CHANGE && !checked) onChange(true)
+      if (dragOffsetX < -DRAG_AMOUNT_TO_CHANGE && checked) onChange(false)
     }
 
     // Reset the dragging attributes.
@@ -63,11 +63,11 @@
         return
       }
 
-      toggle()
+      onChange()
     }}
     {disabled}
     role="switch"
-    aria-checked={on}
+    aria-checked={checked}
   >
     <div
       bind:this={thumb}

--- a/src/components/toggle/toggle.svelte
+++ b/src/components/toggle/toggle.svelte
@@ -110,7 +110,10 @@
       --leo-toggle-checked-color-hover,
       var(--leo-color-primary-60)
     );
-    --unchecked-color: var(--leo-toggle-unchecked-color, var(--leo-color-gray-30));
+    --unchecked-color: var(
+      --leo-toggle-unchecked-color,
+      var(--leo-color-gray-30)
+    );
     --unchecked-color-hover: var(
       --leo-toggle-unchecked-color-hover,
       var(--leo-color-gray-40)


### PR DESCRIPTION
Rename the `on` property on `Toggle` to `checked` as it was conflicting with the event handling type definitions. In future we shouldn't include any properties named `on` or starting with `on` :facepalm: 