### PR TITLE
Fix bug in Skiafy for paths starting with a relative command

### DIFF
--- a/src/scripts/icons/skiafy.js
+++ b/src/scripts/icons/skiafy.js
@@ -87,7 +87,7 @@ function ToCommand(letter, commandIndex) {
   // convert relative commands to their absolute counterparts, for **ONLY** the
   // first command.
   if (commandIndex == 0) {
-    letter = letter.toUpperCase();
+    letter = letter.toUpperCase()
   }
 
   switch (letter) {
@@ -378,12 +378,10 @@ function HandleNode(
 
       // CIRCLE ----------------------------------------------------------------
       case 'circle':
-        const cx = parseFloat(svgElement.getAttribute('cx'))
-          * scaleX
-          + translateX
-        const cy = parseFloat(svgElement.getAttribute('cy'))
-          * scaleY
-          + translateY
+        const cx =
+          parseFloat(svgElement.getAttribute('cx')) * scaleX + translateX
+        const cy =
+          parseFloat(svgElement.getAttribute('cy')) * scaleY + translateY
         const rad = parseFloat(svgElement.getAttribute('r'))
         output += RunHandles(svgElement)
         output += `CIRCLE, ${cx}, ${cy}, ${rad},\n`
@@ -391,12 +389,10 @@ function HandleNode(
 
       // RECT ------------------------------------------------------------------
       case 'rect':
-        const x = (parseFloat(svgElement.getAttribute('x')) || 0)
-          * scaleX
-          + translateX
-        const y = (parseFloat(svgElement.getAttribute('y')) || 0)
-          * scaleY
-          + translateY
+        const x =
+          (parseFloat(svgElement.getAttribute('x')) || 0) * scaleX + translateX
+        const y =
+          (parseFloat(svgElement.getAttribute('y')) || 0) * scaleY + translateY
         const width = parseFloat(svgElement.getAttribute('width'))
         const height = parseFloat(svgElement.getAttribute('height'))
         const round = svgElement.getAttribute('rx') || '0'


### PR DESCRIPTION
For example, this fixes the `pwa-install` Skia Icon, making it look like this:
![image](https://github.com/brave/leo/assets/7678024/4a35ac88-b368-4d8f-86a7-820ac9f60766)

Instead of
![image](https://github.com/brave/leo/assets/7678024/a1023a5a-4c42-48af-a179-7b20929f429a)

This should unblock https://github.com/brave/brave-core/pull/18339

I made this when I was trying to work out what was going on, which I found quite useful:
https://github.com/fallaciousreasoning/skia-icon-editor
https://skia-icon-editor.vercel.app/