### PR TITLE
[Dropdown]: Fixes for use in React

### DIFF
--- a/examples/example-ui-react/src/App.tsx
+++ b/examples/example-ui-react/src/App.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import '../../../tokens/css/variables.css'
 import LeoButton from '../../../react/button'
 import styles from './App.module.css'
+import Dropdown from '../../../react/dropdown'
 
 function App() {
   // Verify that we can change props and children (slots)
@@ -34,6 +35,12 @@ function App() {
             {buttonText}
           </LeoButton>
         )}
+        <div data-theme="dark">
+          <Dropdown value="foo">
+            <leo-option value="foo">Foo</leo-option>
+            <leo-option value="bar">Bar</leo-option>
+          </Dropdown>
+        </div>
         <LeoButton href="#foo">Link button!</LeoButton>
       </header>
     </div>

--- a/src/components/dropdown/dropdown.svelte
+++ b/src/components/dropdown/dropdown.svelte
@@ -1,3 +1,17 @@
+<script context="module" lang="ts">
+  import type { HTMLAttributes } from 'svelte/elements'
+  declare global {
+    namespace JSX {
+      interface IntrinsicElements {
+        'leo-option': HTMLAttributes<HTMLElement> & {
+          value?: string
+          children?: any
+        }
+      }
+    }
+  }
+</script>
+
 <script lang="ts">
   import { createEventDispatcher } from 'svelte'
   import clickOutside from '../../svelteDirectives/clickOutside'
@@ -41,6 +55,7 @@
     for (const [option, index] of options.map((o, i) => [o, i] as const)) {
       option.setAttribute('tabindex', (index + 1).toString())
       if (value === getValue(option)) option.setAttribute('aria-selected', '')
+      else option.removeAttribute('aria-selected')
     }
   }
 
@@ -169,6 +184,7 @@
 
   .leo-dropdown .click-target {
     flex: 1;
+    pointer-events: none;
   }
 
   .leo-dropdown .value {


### PR DESCRIPTION
1. Define `leo-option` element for use in Dropdown. This makes it possible to set from React
2. Remove `aria-selected` attribute - the web component was not regenerating these every change, like Svelte does
3. Disable pointer-events on the button - there was a weird Chromium only bug (which I think is just in Nightly) where it was triggering a double pointer event. It worked (and still works) fine in Firefox.