### PR TITLE
Prefix enum class name before each cases

### DIFF
--- a/src/tokens/transformation/skia/templates/colors.h.template
+++ b/src/tokens/transformation/skia/templates/colors.h.template
@@ -30,7 +30,7 @@ enum class Color {
 
 constexpr SkColor GetColor(Color color, Theme theme) {
   switch (color) {
-<%= groupedTokens.light.allTokens.map(prop => `    case ${prop.name}:
+<%= groupedTokens.light.allTokens.map(prop => `    case Color::${prop.name}:
       return theme == Theme::kLight
         ? leo::light::${prop.name}
         : leo::dark::${prop.name};`).join('\n') %>


### PR DESCRIPTION
`enum class`'s member should be scoped with the name of `enum class`

fix https://github.com/brave/leo/issues/290