### PR TITLE
[Meta] Add `display` property to the CSS for custom elements

### DIFF
--- a/src/components/alert/alert.svelte
+++ b/src/components/alert/alert.svelte
@@ -51,6 +51,10 @@
 </div>
 
 <style lang="scss">
+  :host {
+    display: block;
+  }
+
   :global .leo-alert .actions > *,
   .leo-alert .actions ::slotted(*) {
     display: flex;

--- a/src/components/collapse/collapse.svelte
+++ b/src/components/collapse/collapse.svelte
@@ -54,6 +54,10 @@
 </details>
 
 <style lang="scss">
+  :host {
+    display: block;
+  }
+
   .leoCollapse {
     --background-color: var(
       --leo-collapse-background-color,

--- a/src/components/dropdown/dropdown.svelte
+++ b/src/components/dropdown/dropdown.svelte
@@ -170,6 +170,10 @@
 <svelte:window on:keydown={changeSelection} />
 
 <style lang="scss">
+  :host {
+    display: inline-block;
+  }
+
   .leo-dropdown {
     --dropdown-gap: var(--leo-dropdown-gap, var(--leo-spacing-8));
     --transition-duration: var(--leo-dropdown-transition-duration, 0.12s);

--- a/src/components/label/label.svelte
+++ b/src/components/label/label.svelte
@@ -43,6 +43,10 @@
 </div>
 
 <style lang="scss">
+  :host {
+    display: inline-block;
+  }
+
   .leo-label {
     --icon-size: var(--leo-label-icon-size, 13px);
     --font-text: var(--leo-label-font-text, var(--leo-font-components-label));

--- a/src/components/navdots/navdots.svelte
+++ b/src/components/navdots/navdots.svelte
@@ -44,6 +44,10 @@
 </nav>
 
 <style lang="scss">
+  :host {
+    display: block;
+  }
+
   .leo-navdots {
     --dot-size: var(--leo-navdots-size, 8px);
     // Expanded dot grows to fill half spacing in each direction.

--- a/src/components/progress/progressBar.svelte
+++ b/src/components/progress/progressBar.svelte
@@ -7,6 +7,10 @@
 </div>
 
 <style lang="scss">
+  :host {
+    display: block;
+  }
+
   .leo-progressbar {
     --radius: var(--leo-progressbar-radius, 10px);
     --transition-duration: var(--leo-progressbar-transition-duration, 0.2s);

--- a/src/components/progress/progressRing.svelte
+++ b/src/components/progress/progressRing.svelte
@@ -34,6 +34,10 @@
 </div>
 
 <style lang="scss">
+  :host {
+    display: inline-block;
+  }
+
   @keyframes spin {
     from {
       transform: rotate(0deg);

--- a/src/components/toggle/toggle.svelte
+++ b/src/components/toggle/toggle.svelte
@@ -98,6 +98,10 @@
 </label>
 
 <style lang="scss">
+  :host {
+    display: inline-block;
+  }
+
   .leo-toggle {
     --width: var(--leo-toggle-width, 56px);
     --height: var(--leo-toggle-height, 32px);


### PR DESCRIPTION
By default, custom elements are `display: inline` which is (most of the time) not what is expected. I just ran into this trying to size the `<Alert>` component in React so I thought I'd go through and add my best guess of what should be what. Happy to change anything.