### PR TITLE
Support gradient color for Icons

### DIFF
--- a/src/components/icon/icon.svelte
+++ b/src/components/icon/icon.svelte
@@ -28,6 +28,7 @@
   import type { IconName } from '../../../icons/meta'
   export let name: IconName = undefined
   export let forceColor: boolean = false
+  export let gradient: string = undefined
   $: hasColor =
     name?.endsWith('-color') || name?.startsWith('country-') || forceColor
 </script>
@@ -38,7 +39,9 @@
       <div
         class="icon"
         class:color={hasColor}
+        class:gradient={!!gradient}
         style:--icon-url={`url('${getIconUrl($iconBasePath, name)}')`}
+        style:--icon-gradient={gradient}
       />
     {/if}
   </slot>
@@ -62,7 +65,13 @@
     /* Non color icons are set via a mask-image, so we can change the color
      * by setting the background */
     & .icon:not(.color) {
-      background: var(--icon-color);
+      &.gradient {
+        background: var(--icon-gradient);
+      } 
+      &:not(.gradient) {
+        background: var(--icon-color);
+      }
+
       -webkit-mask-image: var(--icon-url);
       mask-image: var(--icon-url);
       mask-repeat: no-repeat;


### PR DESCRIPTION
For some icons, we need gradient background. 
<img width="495" alt="image" src="https://github.com/brave/leo/assets/5474642/a0aaae32-cc9f-4994-a90d-e59352575d0e">

But It seems we can't pass the gradient value via `color: ...` and `currentColor`. 
So try plumbing a new property

From storybook > Icon > Default > set gradient string.

<img width="284" alt="image" src="https://github.com/brave/leo/assets/5474642/799e4dd3-17f0-4ba0-a64d-a60af7e6e0ef">
