### PR TITLE
Fix JS tokens

### DIFF
--- a/src/tokens/transformation/web/formatCssAsJs.js
+++ b/src/tokens/transformation/web/formatCssAsJs.js
@@ -81,7 +81,10 @@ module.exports = ({ dictionary, file }) => {
   // The `desktop` segment is ignored in our property names, so make sure we
   // remove it from the properties, or this won't match up with the actual CSS
   // variables.
-  const properties = removeSegmentFromNameInAllTokens(dictionary.properties, 'desktop')
+  const properties = removeSegmentFromNameInAllTokens(
+    dictionary.properties,
+    'desktop'
+  )
   const themeObject = formattedVariables(properties)
   // Separate out each main property, to allow for tree shaking and easy type-to-complete
   // imports in code editors.

--- a/src/tokens/transformation/web/formatCssAsJs.js
+++ b/src/tokens/transformation/web/formatCssAsJs.js
@@ -26,7 +26,13 @@ function removeSegmentFromNameInAllTokens(tokenCategory, nameSegment) {
       }
       continue
     }
-    result[key] = removeSegmentFromNameInAllTokens(value, nameSegment)
+
+    const cleaned = removeSegmentFromNameInAllTokens(value, nameSegment)
+    if (key === nameSegment) {
+      Object.assign(result, cleaned)
+    } else {
+      result[key] = cleaned
+    }
   }
   return result
 }
@@ -71,7 +77,12 @@ function formattedVariables(properties) {
 
 module.exports = ({ dictionary, file }) => {
   let fileContents = fileHeader({ file }) + '\n'
-  const themeObject = formattedVariables(dictionary.properties)
+
+  // The `desktop` segment is ignored in our property names, so make sure we
+  // remove it from the properties, or this won't match up with the actual CSS
+  // variables.
+  const properties = removeSegmentFromNameInAllTokens(dictionary.properties, 'desktop')
+  const themeObject = formattedVariables(properties)
   // Separate out each main property, to allow for tree shaking and easy type-to-complete
   // imports in code editors.
   for (const property in themeObject) {

--- a/tests/tokens.js.test.js
+++ b/tests/tokens.js.test.js
@@ -1,19 +1,19 @@
 const fs = require('fs')
 
-describe("JS tokens exist as CSS variables", () => {
-    const css = fs.readFileSync('./tokens/css/variables.css', 'utf-8')
-    const tokenExists = (token) => css.includes(` ${token}:`)
+describe('JS tokens exist as CSS variables', () => {
+  const css = fs.readFileSync('./tokens/css/variables.css', 'utf-8')
+  const tokenExists = (token) => css.includes(` ${token}:`)
 
-    // Unfortunately because the variables JS is an ESModule we can't just
-    // import it here.
-    const variables = fs.readFileSync('./tokens/css/index.js', 'utf-8')
-    const tokenRegex = /var\((.*)\)/gi
+  // Unfortunately because the variables JS is an ESModule we can't just
+  // import it here.
+  const variables = fs.readFileSync('./tokens/css/index.js', 'utf-8')
+  const tokenRegex = /var\((.*)\)/gi
 
-    const matches = variables.matchAll(tokenRegex)
+  const matches = variables.matchAll(tokenRegex)
 
-    for (const match of matches) {
-        it(`${match[1]} is a real CSS variable in variables.css`, () => {
-            expect(tokenExists(match[1])).toBe(true)
-        })
-    }
+  for (const match of matches) {
+    it(`${match[1]} is a real CSS variable in variables.css`, () => {
+      expect(tokenExists(match[1])).toBe(true)
+    })
+  }
 })

--- a/tests/tokens.js.test.js
+++ b/tests/tokens.js.test.js
@@ -1,0 +1,19 @@
+const fs = require('fs')
+
+describe("JS tokens exist as CSS variables", () => {
+    const css = fs.readFileSync('./tokens/css/variables.css', 'utf-8')
+    const tokenExists = (token) => css.includes(` ${token}:`)
+
+    // Unfortunately because the variables JS is an ESModule we can't just
+    // import it here.
+    const variables = fs.readFileSync('./tokens/css/index.js', 'utf-8')
+    const tokenRegex = /var\((.*)\)/gi
+
+    const matches = variables.matchAll(tokenRegex)
+
+    for (const match of matches) {
+        it(`${match[1]} is a real CSS variable in variables.css`, () => {
+            expect(tokenExists(match[1])).toBe(true)
+        })
+    }
+})


### PR DESCRIPTION
Currently, the JS tokens don't exactly match up with the CSS variables. For example, the `desktop` portion of the CSS variables is stripped but not in the tokens. This leads to some JS tokens which don't exist. For example:

`font.desktop.primary.heading.h3: var(--leo-desktop-primary-heading-h3)`, which does not exist. This should be `font.primary.heading.h3: var(--leo-primary-heading-h3)`.

Additionally, this adds a test, so we'll know if we break this again.