### PR TITLE
[Icons]: Update type definitions for icons

### DIFF
--- a/icons/meta.d.ts
+++ b/icons/meta.d.ts
@@ -1,7 +1,7 @@
 import { StringWithAutoComplete } from '../src/types/string'
 
-type Meta = {
-  "updatedAt": 1690099686482,
+const meta = {
+  "updatedAt": 1690157770742,
   "icons": {
     "-pac-color": "-pac-color",
     "0xbtc-color": "0xbtc-color",
@@ -1893,6 +1893,7 @@ type Meta = {
     "zilliqa-color": "zilliqa-color",
     "zrx-color": "zrx-color"
   }
-}
-export default Meta
+} as const
+export type Meta = typeof meta
+export default meta
 export type IconName = StringWithAutoComplete<keyof Meta['icons']>

--- a/icons/meta.js
+++ b/icons/meta.js
@@ -1,5 +1,5 @@
 export default {
-  "updatedAt": 1690099686482,
+  "updatedAt": 1690157770742,
   "icons": {
     "-pac-color": "-pac-color",
     "0xbtc-color": "0xbtc-color",

--- a/src/scripts/update-icons.js
+++ b/src/scripts/update-icons.js
@@ -130,8 +130,9 @@ const generateMeta = () => {
     path.join(FINAL_FOLDER, 'meta.d.ts'),
     `import { StringWithAutoComplete } from '../src/types/string'
 
-type Meta = ${stringified}
-export default Meta
+const meta = ${stringified} as const
+export type Meta = typeof meta
+export default meta
 export type IconName = StringWithAutoComplete<keyof Meta['icons']>`
   )
 }


### PR DESCRIPTION
The current icons meta exports the type as the default export. This means you can't use the icon names, just the type (which doesn't exist at runtime).