### PR TITLE
[Audit]: Don't include node_modules on Windows

### DIFF
--- a/src/scripts/audit-tokens.js
+++ b/src/scripts/audit-tokens.js
@@ -20,7 +20,7 @@ const DEFAULT_EXTENSIONS_TO_CHECK = [
   '.lss',
   '.svelte'
 ]
-const IGNORE = ['/node_modules/']
+const IGNORE = ['node_modules']
 
 /**
  * Extracts all Leo tokens from a piece of text


### PR DESCRIPTION
Windows uses a different path separator (`\\`), so obviously this wasn't ignoring `node_modules`....