### PR TITLE
[Audit]: Don't walk ignored folders

### DIFF
--- a/src/scripts/audit-tokens.js
+++ b/src/scripts/audit-tokens.js
@@ -45,15 +45,14 @@ const extractTokensFromFile = async (file) => {
  * Extracts all tokens from subfiles in a folder with the provided extensions
  * @param {string} folder The folder to search for tokens
  * @param {string[]} extensions The file extensions to check. If undefined, all files will be checked.
+ * @param {string[]} ignore Path segments which should be skipped, like |node_modules|
  * @returns {Promise<string[]>} Not deduplicated
  */
 const extractTokensFromFolder = async (folder, extensions, ignore = []) => {
   const result = []
-  for await (const file of await walk(folder)) {
-    if (ignore.some((i) => file.includes(i))) {
-      continue
-    }
-
+  for await (const file of await walk(folder, (name) =>
+    ignore.some((i) => i === name)
+  )) {
     if (extensions && !extensions.some((e) => file.endsWith(e))) {
       continue
     }

--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -1,15 +1,20 @@
+const { Dirent } = require('fs')
 const fs = require('fs/promises')
 const path = require('path')
 
 /**
  * Recursively walks all files in a folder
- * @param {The directory to walk} dir
+ * @param {string} dir The directory to walk
+ * @param {((name: string, path: string, entry: Dirent) => boolean)?} skip A function for filtering out entries
  * @returns {Promise<AsyncIterable<string>}
  */
-async function* walk(dir) {
+async function* walk(dir, skip) {
   for await (const d of await fs.opendir(dir)) {
     const entry = path.join(dir, d.name)
-    if (d.isSymbolicLink()) continue
+
+    // Allow the consumer to filter out files/folders.
+    if (skip && skip(d.name, entry, d)) continue
+
     if (d.isDirectory()) yield* walk(entry)
     else if (d.isFile()) yield entry
   }

--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -9,6 +9,7 @@ const path = require('path')
 async function* walk(dir) {
   for await (const d of await fs.opendir(dir)) {
     const entry = path.join(dir, d.name)
+    if (d.isSymbolicLink()) continue
     if (d.isDirectory()) yield* walk(entry)
     else if (d.isFile()) yield entry
   }


### PR DESCRIPTION
On windows CI, we're getting into a loop when walking directories, due to recursive hard symlinks. Fortunately, the symlinks are in `node_modules` which we're (mostly) filtering out anyway.

I've updated the walk function to not walk ignored folders, rather than just ignoring entries from ignored folders. This makes the script nearly instant too!