### PR TITLE
Add #pragma once for header files

### DIFF
--- a/src/tokens/transformation/skia/templates/colors.h.template
+++ b/src/tokens/transformation/skia/templates/colors.h.template
@@ -3,6 +3,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // you can obtain one at http://mozilla.org/MPL/2.0/.
 
+#pragma once
+
 #include "third_party/skia/include/core/SkColor.h"
 
 namespace leo::light {

--- a/src/tokens/transformation/skia/templates/radius.h.template
+++ b/src/tokens/transformation/skia/templates/radius.h.template
@@ -3,6 +3,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // you can obtain one at http://mozilla.org/MPL/2.0/.
 
+#pragma once
+
 namespace leo {
 <%= tokens.allTokens.map(prop => {
   return `constexpr int ${prop.name} = ${prop.value}`;

--- a/src/tokens/transformation/skia/templates/spacing.h.template
+++ b/src/tokens/transformation/skia/templates/spacing.h.template
@@ -3,6 +3,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // you can obtain one at http://mozilla.org/MPL/2.0/.
 
+#pragma once
+
 namespace leo {
 <%= tokens.allTokens.map(prop => {
   return `constexpr int ${prop.name} = ${prop.value}`;


### PR DESCRIPTION
Fix #340

Usually we use #ifndef template, but generated resources seems to be okay with #pragma once. Actually, the path could be different on the client source code, `pragma once` makes sense.