### PR TITLE
adds explicit :visited style to button component to avoid conflicts with anchor styles

### DIFF
--- a/src/components/button/button.svelte
+++ b/src/components/button/button.svelte
@@ -91,7 +91,8 @@
     width: 100%;
   }
   // Main styles and states
-  .leoButton {
+  .leoButton,
+  .leoButton:visited:not(:hover) {
     // Gradients cannot have a transition, so we need to reset `transition`
     // to only apply to `box-shadow` and `border-color` in .isHero
     --default-transition: box-shadow 0.12s ease-in-out, color 0.12s ease-in-out,
@@ -111,30 +112,30 @@
     color: var(--color);
     text-decoration: none;
     padding: var(--leo-button-padding, var(--padding-y) var(--padding-x));
+  }
 
-    &:not(:disabled) {
-      &:hover,
-      [data-is-button-target]:hover :host .leoButton,
-      [data-is-button-target]:hover .leoButton {
-        background: var(--bg-hover, var(--bg));
-        color: var(--color-hover, var(--color));
-        box-shadow: var(--box-shadow-hover);
-        border-color: var(--border-color-hover, var(--border-color));
-      }
+  .leoButton:not(:disabled) {
+    &:hover,
+    [data-is-button-target]:hover :host .leoButton,
+    [data-is-button-target]:hover .leoButton {
+      background: var(--bg-hover, var(--bg));
+      color: var(--color-hover, var(--color));
+      box-shadow: var(--box-shadow-hover);
+      border-color: var(--border-color-hover, var(--border-color));
+    }
 
-      &:active {
-        opacity: 0.75;
-        background: var(--bg-active, var(--bg));
-        color: var(--color-active, var(--color-hover, var(--color)));
-      }
+    &:active {
+      opacity: 0.75;
+      background: var(--bg-active, var(--bg));
+      color: var(--color-active, var(--color-hover, var(--color)));
+    }
 
-      &:focus-visible {
-        outline: none;
-        color: var(--color-focus, var(--color));
-        box-shadow: var(--box-shadow-focus);
-        background: var(--bg-focus, var(--bg));
-        border-color: var(--border-color-focus, var(--border-color));
-      }
+    &:focus-visible {
+      outline: none;
+      color: var(--color-focus, var(--color));
+      box-shadow: var(--box-shadow-focus);
+      background: var(--bg-focus, var(--bg));
+      border-color: var(--border-color-focus, var(--border-color));
     }
   }
 


### PR DESCRIPTION
This adds explicit styling for the `:visited` state in order to avoid having styles from `link` apply when the `button` component is an `<a>` tag instead of a `<button>`.

![Screenshot 2023-08-22 at 5 53 54 PM](https://github.com/brave/leo/assets/1199820/04384fbd-2dfc-42aa-95ee-dbbb844a38c1)
