### PR TITLE
[Storybook]: Add button padding to storybook

### DIFF
--- a/src/components/button/button.stories.svelte
+++ b/src/components/button/button.stories.svelte
@@ -17,6 +17,11 @@
   title="Button"
   component={Button}
   argTypes={{
+    '--leo-button-padding': {
+      control: 'text',
+      type: 'string',
+      description: 'The padding to apply to the button content'
+    },
     kind: { control: 'select', options: buttonKinds },
     size: { control: 'select', options: buttonSizes }
   }}


### PR DESCRIPTION
Previously we weren't showing the variable in the storybook