### PR TITLE
[Input]: React cleanup

### DIFF
--- a/examples/example-ui-react/src/App.tsx
+++ b/examples/example-ui-react/src/App.tsx
@@ -16,7 +16,10 @@ function App() {
         <h1>A React App</h1>
         <label>
           Edit the button text:
-          <Input value={buttonText} onInput={e => setButtonText((e.target as any)['value'])} />
+          <Input
+            value={buttonText}
+            onInput={(e) => setButtonText(e.detail.value)}
+          />
         </label>
         {buttonText && (
           <LeoButton

--- a/examples/example-ui-react/src/App.tsx
+++ b/examples/example-ui-react/src/App.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import '../../../tokens/css/variables.css'
 import LeoButton from '../../../react/button'
 import styles from './App.module.css'
+import Input from '../../../react/input'
 import Dropdown from '../../../react/dropdown'
 
 function App() {
@@ -10,16 +11,12 @@ function App() {
   const [spinning, setSpinning] = React.useState(false)
 
   return (
-    <div className={styles['App']}>
+    <div className={styles['App']} data-theme="dark">
       <header className={styles['App-header']}>
         <h1>A React App</h1>
         <label>
           Edit the button text:
-          <input
-            type="text"
-            value={buttonText}
-            onChange={(e) => setButtonText(e.target.value)}
-          />
+          <Input value={buttonText} onInput={e => setButtonText((e.target as any)['value'])} />
         </label>
         {buttonText && (
           <LeoButton

--- a/src/components/input/input.svelte
+++ b/src/components/input/input.svelte
@@ -83,12 +83,13 @@
     focusout: InputEventDetail
   }>()
 
-  function forwardEvent(e: Event & { target: HTMLInputElement }) {
+  function forwardEvent(e: Event) {
+    const event = e as Event & { target: HTMLInputElement }
     dispatch(e.type as any, {
       value,
-      valueAsDate: e.target.valueAsDate,
-      valueAsNumber: e.target.valueAsNumber,
-      innerEvent: e
+      valueAsDate: event.target.valueAsDate,
+      valueAsNumber: event.target.valueAsNumber,
+      innerEvent: event
     })
   }
 

--- a/src/components/input/input.svelte
+++ b/src/components/input/input.svelte
@@ -6,12 +6,12 @@
 
   type OverrideProps = 'type' | 'value' | 'size' | 'class' | `on:${string}`
   type $$Props = Omit<SvelteHTMLElements['input'], OverrideProps> & {
-    type: 'text' | 'password' | 'date' | 'time' | 'color' | 'number'
-    value: string | number | boolean
-    size: Size
-    hasErrors: boolean
-    showErrors: boolean
-    mode: Mode | undefined
+    type?: 'text' | 'password' | 'date' | 'time' | 'color' | 'number'
+    value?: string | number | boolean
+    size?: Size
+    hasErrors?: boolean
+    showErrors?: boolean
+    mode?: Mode | undefined
   }
 
   /**

--- a/src/components/input/input.svelte
+++ b/src/components/input/input.svelte
@@ -3,6 +3,7 @@
   import Button from '../button/button.svelte'
   import FormItem, { type Mode, type Size } from '../formItem/formItem.svelte'
   import Icon from '../icon/icon.svelte'
+  import { createEventDispatcher } from 'svelte'
 
   type OverrideProps = 'type' | 'value' | 'size' | 'class' | `on:${string}`
   type $$Props = Omit<SvelteHTMLElements['input'], OverrideProps> & {
@@ -60,6 +61,37 @@
    */
   export let mode: Mode | undefined = undefined
 
+  type InputEventDetail = {
+    innerEvent: Event & { target: HTMLInputElement }
+    value: string
+    valueAsNumber: number
+    valueAsDate: number
+  }
+
+  // Unfortunately, e.target isn't typed properly by Svelte's type definitions
+  // in web components. This means we need to forward all the events we're
+  // interested in manually, inside our own wrapper.
+  const dispatch = createEventDispatcher<{
+    change: InputEventDetail
+    input: InputEventDetail
+    focus: InputEventDetail
+    blur: InputEventDetail
+    keydown: InputEventDetail
+    keyup: InputEventDetail
+    keypress: InputEventDetail
+    focusin: InputEventDetail
+    focusout: InputEventDetail
+  }>()
+
+  function forwardEvent(e: Event & { target: HTMLInputElement }) {
+    dispatch(e.type as any, {
+      value,
+      valueAsDate: e.target.valueAsDate,
+      valueAsNumber: e.target.valueAsNumber,
+      innerEvent: e
+    })
+  }
+
   const pickerIcons = {
     date: 'calendar',
     time: 'clock'
@@ -90,16 +122,16 @@
       {type}
       {value}
       bind:this={input}
-      on:change
+      on:change={forwardEvent}
       on:input={onInput}
-      on:input
-      on:focus
-      on:blur
-      on:keydown
-      on:keypress
-      on:keyup
-      on:focusin
-      on:focusout
+      on:input={forwardEvent}
+      on:focus={forwardEvent}
+      on:blur={forwardEvent}
+      on:keydown={forwardEvent}
+      on:keypress={forwardEvent}
+      on:keyup={forwardEvent}
+      on:focusin={forwardEvent}
+      on:focusout={forwardEvent}
     />
     <div class="extra">
       <slot name="extra" />


### PR DESCRIPTION
This fixes two issues:
1. Type definitions weren't optional for optional fields :facepalm: 
2. Events weren't typed properly (i.e. `event.target` was being typed as `EventTarget` which made it super unpleasant to use).