### PR TITLE
Avoid error during ssr compile

### DIFF
--- a/src/components/svelte-web.ts
+++ b/src/components/svelte-web.ts
@@ -46,6 +46,10 @@ export default function registerWebComponent(
   component: any,
   { name, mode }: Options
 ) {
+  if (!globalThis.customElements) {
+    console.log(`Component ${name} not registered as there is no customElements in this environment. Perhaps this is an SSR compile, which is not supported for Leo components yet.`)
+    return;
+  }
   if (customElements.get(name)) {
     console.log(`Attempted to register ${name} component multiple times.`)
     return


### PR DESCRIPTION
This doesn't make SSR work, but it attempts to at least include these components in an SSR environment (i.e. nodejs) and not throw an error.