### PR TITLE
CI: Run Deploy on all branches and not only "main"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,7 @@
 name: Deploy
 on:
   pull_request:
-    branches:
-      - main
   push:
-    branches:
-      - main
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
PRs like https://github.com/brave/leo/pull/383 don't have their CI steps run because they are not directly against `main`, but another branch. This fixes that.