### PR TITLE
allow className on leo-menu-item for jsx

### DIFF
--- a/src/components/menu/menu.svelte
+++ b/src/components/menu/menu.svelte
@@ -7,6 +7,9 @@
           // Note: This should line up with Reacts key type, but we don't want
           // to depend on React in this layer, so we just define it manually.
           key?: string | number | null
+          // Menu items can have borders, so we need to allow that.
+          // TODO(petemill): probably make this in to a Component with props and built-in styles
+          className?: string
           children?: any
           onClick?: EventListener
         }


### PR DESCRIPTION
We should probably make leo-menu-item in to a Component to allow for common menu item styles - section titles, separators, etc. In the meantime, we need to consider allowing className so that we can apply border-top