### PR TITLE
Menu item styles and interactivity

### DIFF
--- a/src/components/buttonMenu/buttonMenu.stories.svelte
+++ b/src/components/buttonMenu/buttonMenu.stories.svelte
@@ -6,6 +6,8 @@
   import SlotInfo from '../../storyHelpers/SlotInfo.svelte'
   import Slot from '../../storyHelpers/Slot.svelte'
   import Toggle from '../toggle/toggle.svelte'
+
+  export let toggleIsChecked = false
 </script>
 
 <Meta title="ButtonMenu" component={ButtonMenu} />
@@ -22,20 +24,55 @@
           <Icon name="plus-add" />
         </div>
       </leo-menu-item>
-      <div class="item">
+      <div class="custom-item">
         <div>Suggested questions</div>
-        <Toggle />
+        <Toggle size="small" />
       </div>
+      <!-- svelte-ignore a11y-click-events-have-key-events -->
+      <leo-menu-item
+        class="item"
+        on:click|stopPropagation={(e) => {
+          toggleIsChecked = !toggleIsChecked
+        }}
+        data-is-interactive="true"
+      >
+        <div>Suggested questions</div>
+        <Toggle checked={toggleIsChecked} size="small" />
+      </leo-menu-item>
     </ButtonMenu>
   </div>
 </Template>
 
 <Story name="Default" />
 
+<!-- TODO(petemill): We should probably only allow leo-menu-item for ButtonMenu, otherwise it gets complicated about event dispatching. Alternatively, we
+        should cleanup item selection handling in Menu.svelte and have Menu know whether it is in Select mode or not. -->
 <Story name="Slots" let:args>
-  <SlotInfo
-    description="The ButtonMenu provides several slots for customization. It accepts '<leo-menu-item>' and '<leo-option>' elements as well as any other element types. Use '<leo-menu-item>' for menu-style commands and '<leo-option>' for select-style selectable choices."
-  >
+  <SlotInfo description="">
+    <Slot name="default" explanation="The menu items">
+      <p>
+        The ButtonMenu provides a default slot for menu items. It accepts
+        &lt;leo-menu-item&gt; and &lt;leo-option&gt; elements as well as any
+        other element types.
+      </p>
+      <ul>
+        <li>
+          Use &lt;leo-menu-item&gt; for menu-style commands and
+          &lt;leo-option&gt; for select-style selectable choices.
+        </li>
+        <li>
+          Add the data-is-interactive=true attribute if you want the item to not
+          cause the menu to close when clicked / selected (perhaps its
+          interactive, like a Toggle and you want the user to see that the
+          Toggle changed)
+        </li>
+        <li>
+          Use other element types if you want to handle layout and selection
+          independently (set tabindex to 0 on child interactive elements).
+        </li>
+      </ul>
+    </Slot>
+
     <Slot
       name="anchor-content"
       explanation="A custom icon inside of anchor button"
@@ -70,7 +107,17 @@
     gap: 10px;
   }
 
+  .custom-item {
+    margin: var(--leo-menu-item-margin);
+    padding: var(--leo-menu-item-padding);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16px;
+  }
+
   .section {
+    margin: var(--leo-menu-item-margin);
     border-top: 1px solid rgba(128, 128, 128, 0.225);
     padding-top: 0;
     padding-bottom: 0;


### PR DESCRIPTION
Menu Item enhancements:
- Styling matches figma (hover, selection, focus)
- Pressing enter on the items actually clicks them
- Items can opt out of built-in styles and tabbing / keyboard down arrow and enter press via using a <div> (maybe it's separators or custom interactivity)
- Items can opt out of the menu immediately closing on selection by specifying `data-is-interactive={true}`