### PR TITLE
[Menu]: Remove highlight color

### DIFF
--- a/src/components/menu/menu.svelte
+++ b/src/components/menu/menu.svelte
@@ -52,7 +52,7 @@
         '.leo-menu-popup > :is(leo-menu-item, leo-option'
       ) ??
       []
-  )
+  ) as HTMLElement[]
 
   $: {
     for (const menuItem of menuItems) {

--- a/src/components/menu/menu.svelte
+++ b/src/components/menu/menu.svelte
@@ -237,7 +237,6 @@
   :global .leo-menu-popup > leo-menu-item:hover,
   :global .leo-menu-popup > leo-option:hover {
     background: var(--leo-color-container-highlight);
-    color: var(--leo-color-text-highlight);
   }
 
   :global .leo-menu-popup ::slotted(*[aria-selected]),


### PR DESCRIPTION
The `--leo-color-text-highlight` token does not exist - instead the Menu text color should not change on hover.

In addition, the Typechecking step was failing because the result of `querySelectorAll` is `Element[]` rather than `HTMLElement[]`.

**Note:** This is causing all builds to fail on `main`.