### PR TITLE
[Dropdown]: Fix dropdown bugs introduced during migration to Menu/Floating

### DIFF
--- a/src/components/dropdown/dropdown.svelte
+++ b/src/components/dropdown/dropdown.svelte
@@ -83,6 +83,7 @@
     bind:isOpen
     bind:currentValue={value}
     on:select-item={onItemSelect}
+    on:close={() => button.focus()}
   >
     <slot />
   </Menu>
@@ -105,14 +106,5 @@
   .leo-dropdown .click-target {
     flex: 1;
     pointer-events: none;
-    --glow-size: 3px;
-
-    padding: var(--glow-size);
-
-    &:focus-visible {
-      border-radius: var(--leo-spacing-m);
-      box-shadow: 0px 0px 0px 1.5px rgba(255, 255, 255, 0.5),
-        0px 0px 4px 2px #423eee;
-    }
   }
 </style>


### PR DESCRIPTION
1. Fix sizing: We were applying a padding we didn't need, which resulted in the Dropdown size being 50px instead of 44px
2. Fix focus outline: We were applying a focus outline to the click target resulting in a double focus ring
3. Fix keyboard selection: On selecting a menu item, the control was unfocused, and you couldn't reopen the component.