### PR TITLE
Menu: fix click getting fired twice when clicking menu items

### DIFF
--- a/examples/example-ui-react/src/App.tsx
+++ b/examples/example-ui-react/src/App.tsx
@@ -12,6 +12,9 @@ function App() {
   // Verify that we can change props and children (slots)
   const [buttonText, setButtonText] = React.useState('I am a LEO Button')
   const [spinning, setSpinning] = React.useState(false)
+  const [isThing, setIsThing] = React.useState(false)
+
+  const handleAction = () => console.log('action')
 
   return (
     <div className={styles['App']} data-theme="dark">
@@ -46,8 +49,8 @@ function App() {
         </div>
         <ButtonMenu>
           <div slot="anchor-content">ButtonMenu</div>
-          <leo-menu-item>Llama2-13b</leo-menu-item>
-          <leo-menu-item>Llama2-7b</leo-menu-item>
+          <leo-menu-item onClick={handleAction}>Llama2-13b</leo-menu-item>
+          <leo-menu-item onClick={handleAction}>Llama2-7b</leo-menu-item>
           <div
             style={{
               padding: '10px 0',
@@ -57,12 +60,19 @@ function App() {
           >
             Coding
           </div>
-          <leo-menu-item>Llama2-13b</leo-menu-item>
-          <leo-menu-item>Llama2-7b</leo-menu-item>
-          <div>
+          <leo-menu-item onClick={handleAction}>Llama2-13b</leo-menu-item>
+          <leo-menu-item onClick={handleAction}>Llama2-7b</leo-menu-item>
+          <div onClick={() => setIsThing(!isThing)}>
             <span>Suggested questions</span>
-            <Toggle />
+            <Toggle checked={isThing} />
           </div>
+          <leo-menu-item
+            onClick={() => setIsThing(!isThing)}
+            data-is-interactive={true}
+          >
+            <span>Suggested questions</span>
+            <Toggle checked={isThing} />
+          </leo-menu-item>
         </ButtonMenu>
         <Tooltip text="Hello World">
           <LeoButton href="#foo">Link button!</LeoButton>

--- a/src/components/buttonMenu/buttonMenu.stories.svelte
+++ b/src/components/buttonMenu/buttonMenu.stories.svelte
@@ -8,6 +8,8 @@
   import Toggle from '../toggle/toggle.svelte'
 
   export let toggleIsChecked = false
+
+  const handleAction = () => console.log('action')
 </script>
 
 <Meta title="Components/ButtonMenu" component={ButtonMenu} />
@@ -15,7 +17,8 @@
 <Template let:args>
   <div class="container">
     <ButtonMenu>
-      <leo-menu-item> Copy </leo-menu-item>
+      <!-- svelte-ignore a11y-click-events-have-key-events leo-menu-item peovides key events -->
+      <leo-menu-item on:click={handleAction}> Copy </leo-menu-item>
       <leo-menu-item> Share </leo-menu-item>
       <div class="section">Section</div>
       <leo-menu-item>
@@ -26,18 +29,19 @@
       </leo-menu-item>
       <div class="custom-item">
         <div>Suggested questions</div>
-        <Toggle size="small" />
+        <Toggle bind:checked={toggleIsChecked} size="small" />
       </div>
       <!-- svelte-ignore a11y-click-events-have-key-events -->
       <leo-menu-item
         class="item"
-        on:click|stopPropagation={(e) => {
+        on:click={(e) => {
+          handleAction()
           toggleIsChecked = !toggleIsChecked
         }}
         data-is-interactive="true"
       >
         <div>Suggested questions</div>
-        <Toggle checked={toggleIsChecked} size="small" />
+        <Toggle bind:checked={toggleIsChecked} size="small" />
       </leo-menu-item>
     </ButtonMenu>
   </div>

--- a/src/components/menu/menu.svelte
+++ b/src/components/menu/menu.svelte
@@ -83,9 +83,10 @@
     // a change event.
     if (!item) return
 
-    // Use data-is-interactive=true to prevent the menu from closing when selected. This infers
+    // Use data-is-interactive=true to prevent the menu from closing when selected. This implies
     // there is interacitivity inside the menu item (e.g. a Toggle), which would be good for the user
-    // to see change state and allowing the user to manually close when ready.
+    // to see change state and allowing the user to manually close when ready. In other words, when we want
+    // the styles and menu navigation features of leo-menu-item, but we don't want the auto-close.
     if (
       (item.tagName === 'LEO-OPTION' || item.tagName === 'LEO-MENU-ITEM') &&
       !item.dataset.isInteractive
@@ -102,7 +103,9 @@
       })
     }
 
-    if (item.tagName === 'LEO-MENU-ITEM') {
+    // When using keyboard navigation to call selectMenuItem, ensure click handlers happen on the item,
+    // but not when this was called in a click handler, otherwise we'll get 2x clicks.
+    if (item.tagName === 'LEO-MENU-ITEM' && e.type !== 'click') {
       item.click()
     }
   }


### PR DESCRIPTION
Fix https://github.com/brave/leo/issues/404

> Menu items should not call `element.click()` when clicked, only when using keyboard selection and pressing enter.