### PR TITLE
Set z-index for alert center

### DIFF
--- a/src/components/alert/alertCenter.svelte
+++ b/src/components/alert/alertCenter.svelte
@@ -104,6 +104,7 @@
 <style lang="scss">
   .leo-alert-center {
     --width: var(--leo-alert-center-width, min(540px, 100vw));
+    z-index: var(--leo-alert-center-z-index, 1000);
     position: absolute;
     width: var(--width);
 


### PR DESCRIPTION
Currently, alert UI could be below other UI components. Sets the default z-index and makes a css variables to control the z-index

### Before
<img width="622" alt="before" src="https://github.com/brave/leo/assets/5474642/1c9639de-cef8-4567-91ff-76bef3abe5c7">

### After
<img width="632" alt="after" src="https://github.com/brave/leo/assets/5474642/0eb5107f-e778-4a9c-b67b-d3203610beac">