### PR TITLE
adds loading icon and icon slots to button

### DIFF
--- a/examples/plain-html/index.html
+++ b/examples/plain-html/index.html
@@ -10,6 +10,10 @@
   <link href="./css/variables.css" rel="stylesheet" />
   <title>Web Components</title>
   <style>
+    body {
+      background: var(--leo-color-page-background);
+    }
+
     .component-container {
       display: flex;
       flex-direction: column;

--- a/src/components/button/button.stories.svelte
+++ b/src/components/button/button.stories.svelte
@@ -23,7 +23,8 @@
       description: 'The padding to apply to the button content'
     },
     kind: { control: 'select', options: buttonKinds },
-    size: { control: 'select', options: buttonSizes }
+    size: { control: 'select', options: buttonSizes },
+    isDisabled: { control: 'boolean' }
   }}
 />
 
@@ -40,6 +41,33 @@
     <Slot name="default" explanation="The content of the button">
       <Button {...args}>
         Button <b>can</b> <i>contain</i> <s>HTML</s>
+      </Button>
+    </Slot>
+
+    <Slot
+      name="icon-before"
+      explanation="An icon displayed before the button content"
+    >
+      <Button {...args}>
+        Text
+        <Icon name="check-circle-outline" slot="icon-before" />
+      </Button>
+    </Slot>
+
+    <Slot
+      name="icon-after"
+      explanation="An icon displayed on after the button content"
+    >
+      <Button {...args}>
+        Text
+        <Icon name="check-circle-outline" slot="icon-after" />
+      </Button>
+    </Slot>
+
+    <Slot name="loading" explanation="Text to display if button is loading">
+      <Button {...args} isLoading={true}>
+        <svelte:fragment slot="loading">Loading</svelte:fragment>
+        <Icon name="check-circle-outline" slot="icon-after" />
       </Button>
     </Slot>
   </SlotInfo>
@@ -77,6 +105,21 @@
         {/each}
       </div>
     {/each}
+  {/each}
+</Story>
+
+<Story name="All with icons" let:args>
+  {#each buttonSizes as size}
+    <h2 class="label capitalize">{size}</h2>
+    <div class="button-group">
+      {#each buttonKinds as kind}
+        <Button {kind} {size} {...args}>
+          <Icon name="check-circle-outline" slot="icon-before" />
+          <span class="capitalize">{kind}</span>
+          <Icon name="check-circle-outline" slot="icon-after" />
+        </Button>
+      {/each}
+    </div>
   {/each}
 </Story>
 

--- a/src/components/progress/progressRing.stories.svelte
+++ b/src/components/progress/progressRing.stories.svelte
@@ -20,14 +20,18 @@
       control: 'color',
       description: 'The color of the progress on the progress ring'
     },
-    '--leo-progressring-background-color': {
-      type: 'string',
-      control: 'color',
-      description: 'The color of the progress ring'
-    },
     '--leo-progressring-size': {
       type: 'string',
       description: 'The size of the progress ring'
+    },
+    progress: {
+      control: {
+        type: 'number',
+        min: 0,
+        max: 1,
+        step: 0.1
+      },
+      description: 'A number between 0 and 1 to describe current progress'
     },
     mode: {
       type: 'string',

--- a/src/components/progress/progressRing.svelte
+++ b/src/components/progress/progressRing.svelte
@@ -65,7 +65,7 @@
       animation-duration: var(--spin-rate);
       animation-name: spin;
       animation-iteration-count: infinite;
-      animation-timing-function: linear;
+      animation-timing-function: cubic-bezier(0.17, 0.67, 0.83, 0.67);
     }
 
     circle {

--- a/src/components/progress/progressRing.svelte
+++ b/src/components/progress/progressRing.svelte
@@ -12,24 +12,8 @@
 >
   <slot />
   <svg viewBox="0 0 48 48">
-    <circle
-      style:r="var(--normalized-radius)"
-      style:cx="var(--radius)"
-      style:cy="var(--radius)"
-      style:stroke-width="var(--stroke-width)"
-      stroke="var(--background-color)"
-      fill="transparent"
-    />
-    <circle
-      style:r="var(--normalized-radius)"
-      style:cx="var(--radius)"
-      style:cy="var(--radius)"
-      style:stroke-width="var(--stroke-width)"
-      stroke="var(--stroke-color)"
-      style:stroke-dasharray="var(--circumference) var(--circumference)"
-      style:stroke-dashoffset={'calc(var(--circumference) * (1 - var(--progress)))'}
-      fill="transparent"
-    />
+    <circle class="leo-progressring__background" />
+    <circle class="leo-progressring__ring" />
   </svg>
 </div>
 
@@ -59,10 +43,7 @@
     --normalized-radius: calc(var(--radius) - var(--stroke-width));
     --circumference: calc(var(--normalized-radius) * 2 * 3.141592);
 
-    --background-color: var(
-      --leo-progressring-background-color,
-      var(--leo-color-primary-20)
-    );
+    --background-color: var(--stroke-color);
 
     width: var(--size);
     height: var(--size);
@@ -92,6 +73,22 @@
       transform-origin: 50% 50%;
       transition: stroke-dashoffset var(--transition-duration);
       stroke-linecap: round;
+      r: var(--normalized-radius);
+      cx: var(--radius);
+      cy: var(--radius);
+      stroke-width: var(--stroke-width);
+      fill: transparent;
+    }
+
+    &__background {
+      filter: opacity(0.3);
+      stroke: var(--background-color);
+    }
+
+    &__ring {
+      stroke-dasharray: var(--circumference) var(--circumference);
+      stroke-dashoffset: calc(var(--circumference) * (1 - var(--progress)));
+      stroke: var(--stroke-color);
     }
   }
 </style>


### PR DESCRIPTION
This PR primarily deals with icons in buttons and the button loading state:

1. Adds `<ProgressRing>` as the loading icon for all buttons
  a. Modifies the `<ProgressRing>` component to remove customization of the background ring color as per conversation with @aguscruiz.
  b. Adds a non-linear easing function to `<ProgressRing>`'s indeterminate state.
3. Adds slots for `left-icon` and `right-icon` to button instead of relying on consumer to handle layout
4. Sets button to `disabled` if `isLoading` is true

Out of scope for this PR is adding a determine flag for the button loading icon. This bridge can be crossed when someone finds the need. :-)

**NOTE:** I'd recommend that this PR be `Rebased and merge`d instead of squashed as it has three distinct commits.