### PR TITLE
[Dropdown]: Adds error slot using hasErrors and showErrors

### DIFF
--- a/src/components/dropdown/dropdown.stories.svelte
+++ b/src/components/dropdown/dropdown.stories.svelte
@@ -119,6 +119,19 @@
         <leo-option value="Frob">Frob</leo-option>
       </Dropdown>
     </Slot>
+    <Slot
+      name="error"
+      explanation="A slot where any errors related to the component will be shown. Errors are only shown if showErrors and hasErrors are set on the Dropdown (this one has them forced on)"
+    >
+      <Dropdown {...args} hasErrors showErrors>
+        <leo-option value="Error 1">Error 1</leo-option>
+        <leo-option value="Error 2">Error 2</leo-option>
+        <leo-option value="Error 3">Error 3</leo-option>
+        <div slot="errors">
+          Something is not quite right here!
+        </div>
+      </Dropdown>
+    </Slot>
   </SlotInfo>
 </Story>
 
@@ -197,5 +210,16 @@
     flex-direction: row;
     gap: 8px;
     align-items: center;
+  }
+
+  [slot='errors'] {
+    display: flex;
+    flex-direction: row;
+    gap: var(--leo-spacing-m);
+    align-items: center;
+
+    margin-top: var(--leo-spacing-s);
+
+    color: var(--leo-color-systemfeedback-error-icon);
   }
 </style>

--- a/src/components/dropdown/dropdown.stories.svelte
+++ b/src/components/dropdown/dropdown.stories.svelte
@@ -127,9 +127,7 @@
         <leo-option value="Error 1">Error 1</leo-option>
         <leo-option value="Error 2">Error 2</leo-option>
         <leo-option value="Error 3">Error 3</leo-option>
-        <div slot="errors">
-          Something is not quite right here!
-        </div>
+        <div slot="errors">Something is not quite right here!</div>
       </Dropdown>
     </Slot>
   </SlotInfo>

--- a/src/components/dropdown/dropdown.svelte
+++ b/src/components/dropdown/dropdown.svelte
@@ -107,7 +107,6 @@
   <slot name="errors" />
 {/if}
 
-
 <style lang="scss">
   :host {
     display: inline-block;

--- a/src/components/dropdown/dropdown.svelte
+++ b/src/components/dropdown/dropdown.svelte
@@ -29,6 +29,9 @@
   export let required = false
   export let mode: Mode = 'outline'
 
+  export let hasErrors = false
+  export let showErrors = false
+
   let dispatch = createEventDispatcher()
 
   let isOpen = false
@@ -52,6 +55,7 @@
       bind:size
       {mode}
       showFocusOutline={isOpen}
+      error={hasErrors && showErrors}
     >
       <slot name="label" slot="label" />
       <slot name="left-icon" slot="left-icon" />
@@ -99,6 +103,10 @@
     <slot />
   </Menu>
 </div>
+{#if showErrors && hasErrors}
+  <slot name="errors" />
+{/if}
+
 
 <style lang="scss">
   :host {


### PR DESCRIPTION
Fixes https://github.com/brave/leo/issues/411

Adds error props to the drop down menu. I copied this pattern from the [Input](https://github.com/brave/leo/blob/main/src/components/input/input.svelte#L150) component.

Props:
- `hasErrors`
- `showErrors`
- Adds a slot for a custom error message

Screenshot from storybook:
![image](https://github.com/brave/leo/assets/5668789/d4328960-53da-4da4-bf91-cde5a9806697)
