### PR TITLE
[Component]: adds event types to react

### DIFF
--- a/src/components/button/button.svelte
+++ b/src/components/button/button.svelte
@@ -50,7 +50,9 @@
 
   $: tag = href ? 'a' : ('button' as 'a' | 'button')
 
-  const dispatch = createEventDispatcher()
+  const dispatch = createEventDispatcher<{
+    click: {}
+  }>()
 
   /**
    * Optional click handler

--- a/src/components/checkbox/checkbox.svelte
+++ b/src/components/checkbox/checkbox.svelte
@@ -22,7 +22,10 @@
   export let isDisabled = false
   export let size: Sizes = 'normal'
 
-  const dispatch = createEventDispatcher()
+  const dispatch = createEventDispatcher<{
+    change: { checked: boolean }
+  }>()
+
   function change(e) {
     dispatch('change', {
       checked: e.target.checked

--- a/src/components/collapse/collapse.svelte
+++ b/src/components/collapse/collapse.svelte
@@ -11,7 +11,10 @@
   export let isOpen: boolean | undefined
   $: isOpenInternal = isOpen ?? false
 
-  const dispatcher = createEventDispatcher()
+  const dispatcher = createEventDispatcher<{
+    toggle: { open: boolean }
+  }>()
+
   const toggle = (e) => {
     e.preventDefault()
 

--- a/src/components/dialog/dialog.svelte
+++ b/src/components/dialog/dialog.svelte
@@ -13,7 +13,10 @@
   export let backdropClickCloses = true
   export let animate = true
 
-  const dispatch = createEventDispatcher()
+  const dispatch = createEventDispatcher<{
+    close: {}
+    back: {}
+  }>()
 
   let dialog: HTMLDialogElement
   $: {

--- a/src/components/dropdown/dropdown.svelte
+++ b/src/components/dropdown/dropdown.svelte
@@ -28,10 +28,11 @@
   export let size: Size = 'normal'
   export let required = false
   export let mode: Mode = 'outline'
-
   export let showErrors = false
 
-  let dispatch = createEventDispatcher()
+  let dispatch = createEventDispatcher<{
+    change: { value: string }
+  }>()
 
   let isOpen = false
   let button: HTMLButtonElement

--- a/src/components/radioButton/radioButton.svelte
+++ b/src/components/radioButton/radioButton.svelte
@@ -22,7 +22,9 @@
   export let isDisabled = false
 
   const tagName = 'leo-radiobutton'
-  const dispatch = createEventDispatcher()
+  const dispatch = createEventDispatcher<{
+    change: { value: string | number | any }
+  }>()
 
   function changed(e) {
     if (isDisabled || !e.target.checked) return

--- a/src/components/svelte-react.ts
+++ b/src/components/svelte-react.ts
@@ -6,7 +6,8 @@ import {
   useCallback,
   type ForwardedRef,
   type PropsWithChildren,
-  useState
+  useState,
+  type DOMAttributes
 } from 'react'
 import type { SvelteComponentTyped } from 'svelte'
 
@@ -35,8 +36,6 @@ export type SvelteEvents<T> = T extends SvelteComponentTyped<
   ? Events
   : {}
 export type ReactProps<Props, Events> = Props & {
-  [P in keyof Events as `on${Capitalize<P & string>}`]?: (e: Events[P]) => void
-} & {
   ref?: ForwardedRef<Partial<Props & HTMLElement> | undefined>
 } & {
   // Note: The div here isn't important because all props in intrinsicProps are
@@ -45,6 +44,16 @@ export type ReactProps<Props, Events> = Props & {
   [P in IntrinsicProps]?: JSX.IntrinsicElements['div'][P]
 }
 
+type EventPropsNames = keyof DOMAttributes<unknown>
+
+type EventPropsNameMap = {
+  [P in EventPropsNames as Lowercase<P>]: P
+}
+export type EventProps<T> = {
+  [P in keyof T as P extends Lowercase<EventPropsNames>
+    ? EventPropsNameMap[P]
+    : P]: T[P]
+}
 const useEventHandlers = (props: any) => {
   const [el, setEl] = useState<HTMLElement>()
   const lastValue = useRef<{ [key: string]: (...args: any[]) => any }>({})

--- a/src/components/svelte-react.ts
+++ b/src/components/svelte-react.ts
@@ -52,6 +52,8 @@ type EventPropsNameMap = {
 export type EventProps<T> = {
   [P in keyof T as P extends Lowercase<EventPropsNames>
     ? EventPropsNameMap[P]
+    : P extends `on${infer EventName}`
+    ? `on${Capitalize<EventName>}`
     : P]: T[P]
 }
 const useEventHandlers = (props: any) => {

--- a/src/components/toggle/toggle.svelte
+++ b/src/components/toggle/toggle.svelte
@@ -18,7 +18,10 @@
   let dragStartX: number | undefined
   let dragOffsetX: number = 0
 
-  const dispatch = createEventDispatcher()
+  const dispatch = createEventDispatcher<{
+    change: { checked: boolean }
+  }>()
+
   const onChange = (newValue?: boolean) => {
     if (newValue === undefined) newValue = !checked
     checked = newValue

--- a/src/components/tooltip/tooltip.svelte
+++ b/src/components/tooltip/tooltip.svelte
@@ -33,7 +33,9 @@
   // controlled and uncontrolled states for this component.
   $: visibleInternal = visible ?? false
 
-  const dispatch = createEventDispatcher()
+  const dispatch = createEventDispatcher<{
+    visibilitychange: { visible: boolean }
+  }>()
 
   let tooltip: HTMLElement
   let arrow: HTMLElement


### PR DESCRIPTION
Resolves https://github.com/brave/leo/issues/407

For react components, currently  generic typing allows any event prop to be used (e.g. `<LeoButton onClick={...}>`), if an incorrect event name is used (e.g. `<LeoButton onClicked={...}>`) there is no type error. Ideally a type error for an incorrect prop name would show.

This solves this by generating an event type for the react components by parsing the corresponding svelte type file, it should contain event types resulting from the typed `createEventDispatcher`. When there are no events defined in the svelte file it doesn't include any event types.

For example, in [input.svelte#L74-L84](https://github.com/brave/leo/blob/7a65a548c3c801fcdf8b86a98118a758bfa004c8/src/components/input/input.svelte#L74-L84):

```ts
  type InputEventDetail = {
    innerEvent: Event & { target: HTMLInputElement }
    value: string
    valueAsNumber: number
    valueAsDate: number
  }

  const dispatch = createEventDispatcher<{
    change: InputEventDetail
    input: InputEventDetail
    focus: InputEventDetail
    blur: InputEventDetail
    keydown: InputEventDetail
    keyup: InputEventDetail
    keypress: InputEventDetail
    focusin: InputEventDetail
    focusout: InputEventDetail
  }>()
```

Results in a type definition that looks like this:
```ts
import type * as React from 'react'
import type { ReactProps } from '../src/components/svelte-react'
import type { InputEvents as SvelteEvents, InputProps as SvelteProps } from '../types/components/input/input.svelte';

export type InputEventProps = {
  onChange?: (event: CustomEvent<{
      innerEvent: Event & {
          target: HTMLInputElement;
      };
      value: string;
      valueAsNumber: number;
      valueAsDate: number;
  }) => void;
  onInput?: (event: CustomEvent<{...}>) => void;
  onFocus?: (event: CustomEvent<{...}>) => void;
  onBlur?: (event: CustomEvent<{...}>) => void;
  onKeydown?: (event: CustomEvent<{...}>) => void;
  onKeyup?: (event: CustomEvent<{...}>) => void;
  onKeypress?: (event: CustomEvent<{...}>) => void;
  onFocusin?: (event: CustomEvent<{...}>) => void;
  onFocusout?: (event: CustomEvent<{...}>) => void
}

export type InputProps = InputEventProps & ReactProps<SvelteProps, SvelteEvents>;
export default function InputReact(props: React.PropsWithChildren<InputProps>): JSX.Element

// As we don't currently have type definitions for the web components, export
// the Type Definitions from the Svelte component.
export * from '../types/components/input/input.svelte'
```

https://github.com/brave/leo/assets/5668789/e27cbc1e-7a9c-4162-9710-21fdce5a46ed