### PR TITLE
Input fixes

### DIFF
--- a/src/components/formItem/formItem.svelte
+++ b/src/components/formItem/formItem.svelte
@@ -54,11 +54,11 @@
 
 <label
   class="leo-control"
-  class:small={size === 'small'}
-  class:large={size === 'large'}
-  class:filled={mode === 'filled'}
-  class:outline={mode !== 'filled'}
-  class:focus={showFocusOutline}
+  class:isSmall={size === 'small'}
+  class:isLarge={size === 'large'}
+  class:isFilled={mode === 'filled'}
+  class:isOutline={mode !== 'filled'}
+  class:isFocused={showFocusOutline}
   class:error
   aria-disabled={disabled}
 >
@@ -127,7 +127,7 @@
       }
 
       & .container:has(*:focus-visible),
-      &.focus .container {
+      &.isFocused .container {
         color: var(--color-focus);
         background: var(--background-focus);
         box-shadow: var(--shadow-focus);
@@ -140,28 +140,28 @@
     }
   }
 
-  .leo-control.small {
+  .leo-control.isSmall {
     --leo-icon-size: 16px;
     --font: var(--leo-control-font, var(--leo-font-primary-small-regular));
     --padding: var(--leo-control-padding, 8px);
     --gap: var(--leo-control-label-gap, 2px);
   }
 
-  .leo-control.large {
+  .leo-control.isLarge {
     --leo-icon-size: 22px;
     --padding: var(--leo-control-padding, 14px 8px);
     --gap: var(--leo-control-label-gap, 12px);
   }
 
-  .leo-control.filled {
+  .leo-control.isFilled {
     --background: var(--leo-color-container-highlight);
     --shadow-hover: var(--leo-effect-elevation-01);
     --border-color: transparent;
     --border-color-hover: var(--leo-color-divider-subtle);
   }
 
-  .leo-control.outline {
-    --background: var(--light-container-background);
+  .leo-control.isOutline {
+    --background: var(--leo-color-container-background);
     --background-hover: var();
     --border-color: var(--leo-color-divider-strong);
     --border-color-hover: var(--leo-color-gray-30);

--- a/src/components/input/input.svelte
+++ b/src/components/input/input.svelte
@@ -6,8 +6,25 @@
   import { createEventDispatcher } from 'svelte'
 
   type OverrideProps = 'type' | 'value' | 'size' | 'class' | `on:${string}`
+  type LeoInputTypeAttribute =
+    | 'color'
+    | 'date'
+    | 'datetime-local'
+    | 'email'
+    | 'file'
+    | 'hidden'
+    | 'month'
+    | 'number'
+    | 'password'
+    | 'range'
+    | 'search'
+    | 'tel'
+    | 'text'
+    | 'time'
+    | 'url'
+    | 'week'
   type $$Props = Omit<SvelteHTMLElements['input'], OverrideProps> & {
-    type?: 'text' | 'password' | 'date' | 'time' | 'color' | 'number'
+    type?: LeoInputTypeAttribute
     value?: string | number | boolean
     size?: Size
     hasErrors?: boolean


### PR DESCRIPTION
- adds more support for default attributes on Input component

Currently, the input component doesn't support `type="email"`, this PR adds support for that and other input types which we may want to use.

- fixes background color on formControl and renames classes

The primary fix here is an incorrect CSS var, but I've additionally renamed the classes to follow suit with the Button component: `isFilled`, `isOutline`, etc. This is helpful especially in the context of projects that use the extracted component styles as Tailwind plugins since `outline` is a default class to style the `outline` property on interactive elements.
