### PR TITLE
splits tailwind component plugins into individual imports

### DIFF
--- a/src/tokens/transformation/tailwind/static/plugins/index.ts
+++ b/src/tokens/transformation/tailwind/static/plugins/index.ts
@@ -1,10 +1,17 @@
-const { readdirSync } = require('fs')
-const { parse } = require('path')
+const plugins: string[] = []
 
-const plugins = readdirSync(__dirname).filter((file) => {
-  const { name } = parse(file)
-  return name !== 'index' && !name.startsWith('_')
-})
+// Prevent global issues with TS
+;(function () {
+  const { readdirSync } = require('fs')
+  const { parse } = require('path')
+
+  for (const file of readdirSync(__dirname, { withFileTypes: true })) {
+    const { name } = parse(file.name)
+    if (file.isFile() && name !== 'index' && !name.startsWith('_')) {
+      plugins.push(name)
+    }
+  }
+})()
 
 module.exports = plugins.map((file) => {
   return require(`./${file}`)


### PR DESCRIPTION
This makes it so that Tailwind component plugins (extracted from the Svelte components) can be imported individually into a project's Tailwind config instead of all at once.
