### PR TITLE
[Tooltip]: adds arrow on tooltip default mode

### DIFF
--- a/src/components/floating/floating.svelte
+++ b/src/components/floating/floating.svelte
@@ -96,7 +96,7 @@
   }
 </script>
 
-<div bind:this={floating} class="leo-floating">
+<div on:mouseenter on:mouseleave bind:this={floating} class="leo-floating">
   <slot />
 </div>
 


### PR DESCRIPTION
Resolves https://github.com/brave/leo/issues/444

Right now tooltips on default mode don't show an arrow. This PR adds an arrow and solves an issue with the tooltip disappearing when trying to interact with the content (such as a button).

### Screenshots
![image](https://github.com/brave/leo/assets/5668789/6410507f-c94c-4906-b8fc-b554f4d70a1f)
![image](https://github.com/brave/leo/assets/5668789/dc106d4d-8aad-4ed3-ae98-7f39857e6692)


#### Before

https://github.com/brave/leo/assets/5668789/5c9048f7-9489-4ea2-8adf-00bc1ee8be55


#### After

https://github.com/brave/leo/assets/5668789/ccf18a7f-0045-49ab-a145-90434825aef4

