### PR TITLE
(ci): fixes formatting for preview links in PR comment post-deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,8 +74,8 @@ jobs:
               repo: context.repo.repo,
               body: `👋 Thanks for Submitting! This PR is available for preview at the link below.
 
-                ✅ PR tip preview: https://${{ github.event.workflow_run.pull_requests[0].number }}.pr.nala.bravesoftware.com/
-                ✅ Commit preview: https://${{ github.event.workflow_run.pull_requests[0].number }}.pr.nala.bravesoftware.com/commit-${{ github.event.workflow_run.head_sha }}/
+            ✅ PR tip preview: https://${{ github.event.workflow_run.pull_requests[0].number }}.pr.nala.bravesoftware.com/
+            ✅ Commit preview: https://${{ github.event.workflow_run.pull_requests[0].number }}.pr.nala.bravesoftware.com/commit-${{ github.event.workflow_run.head_sha }}/
 
             <details>
             <summary>Variables Diff</summary>


### PR DESCRIPTION
Currently, the PR comment format is off due to indentation triggering Markdown quotation code block styling:

![Screenshot 2023-10-27 at 12 41 50 PM](https://github.com/brave/leo/assets/1199820/98774997-264a-4b3d-8954-e7da9eccb84f)
