### PR TITLE
Detect error slot for inputs instead of hasErrors prop

### DIFF
--- a/src/components/dropdown/dropdown.stories.svelte
+++ b/src/components/dropdown/dropdown.stories.svelte
@@ -121,9 +121,9 @@
     </Slot>
     <Slot
       name="error"
-      explanation="A slot where any errors related to the component will be shown. Errors are only shown if showErrors and hasErrors are set on the Dropdown (this one has them forced on)"
+      explanation="A slot where any errors related to the component will be shown. Errors are only shown if showErrors is set and an error slot exists on the Dropdown (this one has them forced on)"
     >
-      <Dropdown {...args} hasErrors showErrors>
+      <Dropdown {...args} showErrors>
         <leo-option value="Error 1">Error 1</leo-option>
         <leo-option value="Error 2">Error 2</leo-option>
         <leo-option value="Error 3">Error 3</leo-option>

--- a/src/components/dropdown/dropdown.svelte
+++ b/src/components/dropdown/dropdown.svelte
@@ -102,7 +102,7 @@
     <slot />
   </Menu>
 </div>
-{#if showErrors && $$slots.errors}
+{#if showErrors}
   <slot name="errors" />
 {/if}
 

--- a/src/components/dropdown/dropdown.svelte
+++ b/src/components/dropdown/dropdown.svelte
@@ -29,7 +29,6 @@
   export let required = false
   export let mode: Mode = 'outline'
 
-  export let hasErrors = false
   export let showErrors = false
 
   let dispatch = createEventDispatcher()
@@ -55,7 +54,7 @@
       bind:size
       {mode}
       showFocusOutline={isOpen}
-      error={hasErrors && showErrors}
+      error={showErrors && $$slots.errors}
     >
       <slot name="label" slot="label" />
       <slot name="left-icon" slot="left-icon" />
@@ -103,7 +102,7 @@
     <slot />
   </Menu>
 </div>
-{#if showErrors && hasErrors}
+{#if showErrors && $$slots.errors}
   <slot name="errors" />
 {/if}
 

--- a/src/components/input/input.stories.svelte
+++ b/src/components/input/input.stories.svelte
@@ -95,9 +95,9 @@
     </Slot>
     <Slot
       name="errors"
-      explanation="A slot where any errors related to the component will be shown. Errors are only show if showErrors and hasErrors are set on the Input (this one has them forced on)"
+      explanation="A slot where any errors related to the component will be shown. Errors are only show if showErrors is set and an error slot exists on the Input (this one has them forced on)"
     >
-      <Input {...args} hasErrors showErrors>
+      <Input {...args} showErrors>
         <div slot="errors">
           Your password must contain a proof of Pythagoras' theorem!
         </div>

--- a/src/components/input/input.svelte
+++ b/src/components/input/input.svelte
@@ -27,7 +27,6 @@
     type?: LeoInputTypeAttribute
     value?: string | number | boolean
     size?: Size
-    hasErrors?: boolean
     showErrors?: boolean
     mode?: Mode | undefined
   }
@@ -60,13 +59,6 @@
    * The size of the input.
    */
   export let size: Size = 'normal'
-
-  /**
-   * Whether the component has any errors. If true, and showErrors is set then
-   * the errors slot will be rendered and the component will show in its error
-   * state.
-   */
-  export let hasErrors = false
 
   /**
    * Whether any errors the component has should be shown.
@@ -129,7 +121,7 @@
   bind:disabled
   {size}
   {mode}
-  error={(hasErrors || hasErrorsInternal) && showErrors}
+  error={($$slots.errors || hasErrorsInternal) && showErrors}
 >
   <slot name="left-icon" slot="left-icon" />
   <div class="input-container">
@@ -164,7 +156,7 @@
   </slot>
   <slot slot="label" />
 </FormItem>
-{#if showErrors && hasErrors}
+{#if showErrors && $$slots.errors}
   <slot name="errors" />
 {/if}
 

--- a/src/components/input/input.svelte
+++ b/src/components/input/input.svelte
@@ -156,7 +156,7 @@
   </slot>
   <slot slot="label" />
 </FormItem>
-{#if showErrors && $$slots.errors}
+{#if showErrors}
   <slot name="errors" />
 {/if}
 


### PR DESCRIPTION
Resolves https://github.com/brave/leo/issues/455

Currently to show error messages on inputs, `hasErrors` prop is passed. This uses `$$slots.errors` instead of exposing the `hasErrors` prop, implemented on `Dropdown` and `Input` components.

### With slot present
Dropdown:
<img width="619" alt="Screenshot 2023-10-30 at 11 05 58 AM" src="https://github.com/brave/leo/assets/5668789/6dd2a647-4e5b-4b1f-8e2e-e9e7f990f4d9">

Input:
<img width="619" alt="Screenshot 2023-10-30 at 11 05 36 AM" src="https://github.com/brave/leo/assets/5668789/e0888224-25e3-41db-9b06-43d65446ecb6">


### Without slot present

Dropdown:
<img width="619" alt="image" src="https://github.com/brave/leo/assets/5668789/fb38b166-b6c2-483b-a064-3dc74ca160db">

Input:
<img width="619" alt="image" src="https://github.com/brave/leo/assets/5668789/e554ce4c-3106-4687-bddd-bd40eca865c9">

