### PR TITLE
[Tooltip]: Validates arrow positioning / adds timeout props

### DIFF
--- a/src/components/floating/floating.svelte
+++ b/src/components/floating/floating.svelte
@@ -60,6 +60,10 @@
     return result
   }
 
+  function hasInvalidArrowPosition({ x, y }: { x?: number; y?: number }) {
+    return (!x && !y) || x <= 1 || y <= 1
+  }
+
   function updatePosition(...args: any[]) {
     if (!floating || !target) return
 
@@ -67,6 +71,8 @@
       placement: placement,
       middleware: getMiddlewares(flip, shift, offset, middleware)
     }).then(({ x, y, placement, middlewareData }) => {
+      if (hasInvalidArrowPosition(middlewareData.arrow)) return
+
       if (floating) {
         Object.assign(floating.style, {
           left: `${x}px`,

--- a/src/components/floating/floating.svelte
+++ b/src/components/floating/floating.svelte
@@ -60,6 +60,9 @@
     return result
   }
 
+  // We need this check because the middleware sometimes generates an
+  // x or y value of undefined, 1, or less. This causes the arrow on
+  // the floating element to be positioned in the corner incorrectly.
   function hasInvalidArrowPosition({ x, y }: { x?: number; y?: number }) {
     return (!x && !y) || x <= 1 || y <= 1
   }

--- a/src/components/tooltip/tooltip.svelte
+++ b/src/components/tooltip/tooltip.svelte
@@ -18,8 +18,16 @@
   export let offset: number = 8
   export let mode: Mode = 'mini'
 
+  /** The length of time the tooltip is open in ms after mouse leave of
+   * the trigger or tooltip */
+  export let mouseleaveTimeout: number = 150
+
   /* Whether the tooltip is currently visible */
   export let visible: boolean | undefined = undefined
+
+  /** The length of time in ms the tooltip element takes to fade
+   * after the users mouse leaves the trigger or tooltip*/
+  export let fadeDuration: number = 0
 
   // Note: This is separate from the |visible| flag because we want to handle
   // controlled and uncontrolled states for this component.
@@ -70,7 +78,7 @@
         if (!triggerHovered && !tooltipHovered) {
           setVisible(false)
         }
-      }, 150)
+      }, mouseleaveTimeout)
     }
   })()
 
@@ -116,8 +124,8 @@
         class:hero={mode === 'hero'}
         class:info={mode === 'info'}
         class:mini={mode === 'mini'}
+        transition:fade={{ duration: fadeDuration }}
         class:default={mode === 'default' || !mode}
-        transition:fade={{ duration: 60 }}
         hidden={!visibleInternal}
         bind:this={tooltip}
       >


### PR DESCRIPTION
Right now in main, if you hover over a tooltip and hover out a few times, the arrow positioning sometimes computes incorrectly. This fixes it by validating arrow positioning before firing the `computedposition` event on the `Floating` element.

This PR also adds a few other things discussed with @fallaciousreasoning, a prop named `mouseleaveTimeout` for the debounce timeout on the mouse leave event, and defaults to no fadeout animation on the tooltip, with a prop named `fadeDuration` to set it if desired.

### Screenshots
#### Arrow Position Bug Before

https://github.com/brave/leo/assets/5668789/db216dc8-16eb-48cf-bd8e-6256dea8656c

#### Arrow Position Bug After

https://github.com/brave/leo/assets/5668789/9d1c07d5-8694-4436-a6f2-56845b6507ef


https://github.com/brave/leo/assets/5668789/d071c71b-5bbc-4d00-8243-8bd8a425039d


