### PR TITLE
[Events]: Fix regex for extracting event types

### DIFF
--- a/src/scripts/gen-react-bindings.js
+++ b/src/scripts/gen-react-bindings.js
@@ -32,7 +32,7 @@ const findEventsTypeDefinition = async (svelteFilePath, componentName) => {
   )
   const fileContents = await fs.readFile(pathToType)
 
-  const typeRegex = /\s+([a-zA-Z0-9]+): (CustomEvent<{(\n|.)*?}>)/gm
+  const typeRegex = /\s+([a-zA-Z0-9]+): (CustomEvent<((.|\n)*?)>)/gm
 
   const componentEventNames = [
     ...fileContents.toString().matchAll(typeRegex)


### PR DESCRIPTION
The old event regex was only matching types defined in place (i.e. `{ foo: number }`), so was breaking for `undefined`, `any` and `never`.

This seems to have been triggered by the Svelte4 upgrade (previously, undefined event types would be `{}` but now they're either `undefined` or `any`).