### PR TITLE
[Tooltip]: Fix unhandled error in positionArrow

### DIFF
--- a/src/components/tooltip/tooltip.svelte
+++ b/src/components/tooltip/tooltip.svelte
@@ -46,6 +46,9 @@
   function positionArrow(
     e: CustomEvent<{ middlewareData: MiddlewareData; placement: Placement }>
   ) {
+
+    if(!e.detail.middlewareData.arrow) return
+
     const { x: arrowX, y: arrowY } = e.detail.middlewareData.arrow as {
       x?: number
       y?: number


### PR DESCRIPTION
# What?

Fixes an unhandled error caused by deleting the `middlewareData.arrow` property in the floating component.

Fixes this issue:

https://github.com/brave/leo/assets/5668789/9f9088ec-c12f-45e7-8764-38220fa502c7

@fallaciousreasoning This was caused by https://github.com/brave/leo/pull/469, and in this PR I'm assuming returning early is ok in the tooltip here (it doesn't seem to cause any other bugs).

