### PR TITLE
[Tooltip]: Fix scroll on screen using width: max-content css prop

### DIFF
--- a/src/components/tooltip/tooltip.svelte
+++ b/src/components/tooltip/tooltip.svelte
@@ -173,6 +173,7 @@
   }
 
   .leo-tooltip .tooltip {
+    width: max-content;
     background: var(--background);
     color: var(--text);
     box-shadow: var(--shadow);


### PR DESCRIPTION
Closes https://github.com/brave/leo/issues/477

When the content inside the tooltip is without a defined width, such as when it is text content, there is a scroll effect as the `floating-ui` library computes the max content width - only when along an edge of the browser. Adding `width: max-content;` fixes it for when the tooltip content is just text.

### Before

https://github.com/brave/leo/assets/5668789/453d9630-a15b-4d7a-9a38-f91beaaa73ba

### After

https://github.com/brave/leo/assets/5668789/d54e5348-623e-4ca4-b24a-61e1b7beab51

