### PR TITLE
[Menu]: Fix scroll on screen using width: max-content css prop

### DIFF
--- a/src/components/menu/menu.svelte
+++ b/src/components/menu/menu.svelte
@@ -223,7 +223,7 @@
 
     border: 1px solid var(--leo-color-divider-subtle);
     border-radius: var(--leo-radius-m);
-    width: 100%;
+    width: max-content;
     display: flex;
     flex-direction: column;
   }


### PR DESCRIPTION
Part of https://github.com/brave/leo/issues/391

On the menu there is a scroll effect as the `floating-ui` library computes the max content width. Adding `width: max-content;` fixes this issue, this is mentioned in the docs here: https://floating-ui.com/docs/computePosition#initial-layout

I found this solution while fixing https://github.com/brave/leo/pull/477 which is the same problem just manifested a bit differently.

### Screenshots
#### Before

https://github.com/brave/leo/assets/5668789/b163ae59-2139-48b3-bcaf-2cae6d2c43a5

#### After

https://github.com/brave/leo/assets/5668789/f0252160-0c62-473a-9f01-7f9edcc1638c

