### PR TITLE
[Menu] Adds size middleware

### DIFF
--- a/src/components/menu/menu.svelte
+++ b/src/components/menu/menu.svelte
@@ -24,6 +24,7 @@
   import { createEventDispatcher } from 'svelte'
   import clickOutside from '../../svelteDirectives/clickOutside'
   import Floating from '../floating/floating.svelte'
+  import { size as sizeMiddleware } from '@floating-ui/dom'
 
   interface CloseEventDetail {
     originalEvent: Event
@@ -171,11 +172,17 @@
   function handleBlur(e: MouseEvent) {
     dispatchClose(e, 'blur')
   }
+
+  function applySizeMiddleware({rects, availableHeight}) {
+    popup.style.maxHeight = `calc(${availableHeight}px - var(--leo-spacing-xl))`;
+  }
+
+  let floatingMiddleware = [sizeMiddleware({apply: applySizeMiddleware })];
 </script>
 
 <div class="leo-menu" use:clickOutside={isOpen && handleBlur}>
   {#if isOpen}
-    <Floating {target} placement="bottom-start" autoUpdate>
+    <Floating {target} placement="bottom-start" autoUpdate middleware={floatingMiddleware}>
       <div
         class="leo-menu-popup"
         id="menu"


### PR DESCRIPTION
closes https://github.com/brave/leo/issues/391

Uses the [floating ui size middleware](https://floating-ui.com/docs/size) to keep menus from overflowing the scroll container.

## Before


https://github.com/brave/leo/assets/5668789/e937e68c-ac1c-4a83-8ef9-52979ec8d5cc


https://github.com/brave/leo/assets/5668789/b3453112-bd36-4ab1-9378-8a960f94bc1a


## After

https://github.com/brave/leo/assets/5668789/b684a6e4-a992-4845-8c54-a50d3d504be7


https://github.com/brave/leo/assets/5668789/b798aff6-8bde-4a27-aea3-09443ada1d82


