### PR TITLE
[Svelte]: Add support for $$restProps in Web Components

### DIFF
--- a/examples/example-ui-react/src/App.tsx
+++ b/examples/example-ui-react/src/App.tsx
@@ -25,6 +25,7 @@ function App() {
           Edit the button text:
           <Input
             value={buttonText}
+            placeholder="Set button text"
             onInput={(e) => setButtonText(e.detail.value)}
           />
         </label>

--- a/examples/plain-html/index.html
+++ b/examples/plain-html/index.html
@@ -167,7 +167,7 @@
     <leo-tooltip text="toggles the collapse & stuff" mode="hero">
       <leo-button kind="outline" id="toggle-button"></leo-button>
     </leo-tooltip>
-    <leo-input value="Leo Button" required showErrors>
+    <leo-input value="Leo Button" placeholder="Enter button text" required showErrors>
       What does the button say?
     </leo-input>
     <leo-progressring progress="0.25"></leo-progressring>

--- a/examples/plain-html/perf.html
+++ b/examples/plain-html/perf.html
@@ -1,0 +1,135 @@
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#000000" />
+  <meta
+    name="description"
+    content="Web site created using HTML & Web Components" />
+  <link href="./css/variables.css" rel="stylesheet" />
+  <title>Web Components Perf</title>
+  <style>
+    body {
+      background: var(--leo-color-page-background);
+    }
+  </style>
+</head>
+
+<body>
+  <noscript>You need to enable JavaScript to run this app.</noscript>
+  <script type="module">
+    import './leo/button.js'
+
+    const container = document.querySelector('.container')
+
+    function createDestroy(n) {
+        for (let i = 0; i < n; ++i) {
+            const button = document.createElement('leo-button')
+            container.appendChild(button)
+        }
+
+        for (const button of container.querySelectorAll('leo-button')) {
+            button.remove()
+        }
+    }
+
+    function changeProps(n) {
+        const changes = [
+            { kind: 'small' },
+            { tabindex: -1 },
+            { size: 'large'},
+            { fab: true },
+            { href: 'https://brave.com' },
+            { href: undefined },
+            { disabled: true },
+            { disabled: null },
+            { formaction: 'POST' },
+            { type: 'button' },
+            { type: 'submit' }
+        ]
+
+        for (let i = 0; i< n; ++ i) {
+            const button = document.createElement('leo-button')
+            container.appendChild(button)
+
+            for (const change of changes) {
+                const [key, value] = Object.entries(change)[0]
+                button[key] = value
+            }
+        }
+    }
+
+    function changeAttributes(n) {
+        const changes = [
+            { kind: 'small' },
+            { tabindex: -1 },
+            { size: 'large'},
+            { fab: true },
+            { href: 'https://brave.com' },
+            { href: undefined },
+            { disabled: true },
+            { disabled: null },
+            { formaction: 'POST' },
+            { type: 'button' },
+            { type: 'submit' }
+        ]
+
+        for (let i = 0; i< n; ++ i) {
+            const button = document.createElement('leo-button')
+            container.appendChild(button)
+
+            for (const change of changes) {
+                const [key, value] = Object.entries(change)[0]
+                if (value !== null)
+                    button.setAttribute(key, value)
+                else
+                    button.removeAttribute(key)
+            }
+        }
+    }
+
+    function changeSlotted(n) {
+        for (let i = 0; i < n; ++i) {
+            const button = document.createElement('leo-button')
+            container.appendChild(button)
+
+            button.innerHTML = `<div>Hello World</div>`
+            button.innerHTML = ``
+
+            const span = document.createElement('span')
+            span.innerText = "Foo"
+            button.appendChild(span)
+
+            const icon = document.createElement('span')
+            icon.setAttribute('slot', 'icon-before')
+            icon.innerText = "Bar"
+            button.appendChild(icon)
+
+            icon.remove()
+            span.remove()
+        }
+    }
+
+    function time(name, func) {
+        container.innerHTML = ''
+
+        const start = performance.now()
+        func()
+        const end = performance.now()
+
+        console.log(name, "took", end - start)
+    }
+
+    const iterations = 100000
+    time("Create/Destroy", () => createDestroy(iterations))
+    time("Change Props", () => changeProps(iterations))
+    time("Change Attributes", () => changeAttributes(iterations))
+    time("Change Slots", () => changeSlotted(iterations))
+  </script>
+  <div class="container">
+    
+  </div>
+</body>
+
+</html>

--- a/src/components/svelte-react.ts
+++ b/src/components/svelte-react.ts
@@ -149,7 +149,7 @@ export default function SvelteWebComponentToReact<
         // behavior, and triggers a TrustedTypes error.
         for (const [key, value] of Object.entries(props)) {
           if (eventRegex.test(key) || key === 'children') continue
-          ;(component.current as any)[key] = value
+          ;(component.current as any).svelteProps[key] = value
         }
       }, [props])
 

--- a/src/components/svelte-web.ts
+++ b/src/components/svelte-web.ts
@@ -77,6 +77,13 @@ export default function registerWebComponent(
     props.filter((p) => typeof c.$$.ctx[c.$$.props[p]] === 'boolean')
   )
 
+  // Heuristics for determining if a property is a boolean.
+  const isBooleanProperty = (prop: string, value: any) => typeof value === "boolean"
+    || boolProperties.has(prop)
+    // This check is a bit scary - not sure if there's a better way of doing
+    // this though
+    || (value === '' && prop.startsWith('is'))
+
   type Callback = (...args: any[]) => void
   class SvelteWrapper extends HTMLElement {
     // A map of event name to a map of an event listener to a function for
@@ -227,7 +234,7 @@ export default function registerWebComponent(
           if (reflectToAttributes.has(typeof value)) {
             // Boolean attributes are special - presence/absence indicates
             // value, rather than actual value.
-            if (boolProperties.has(prop)) {
+            if (isBooleanProperty(prop, value)) {
               if (value) el.setAttribute(prop, '')
               else el.removeAttribute(prop)
             } else el.setAttribute(prop, value)
@@ -263,7 +270,7 @@ export default function registerWebComponent(
       // MutationObserver) won't fire until we've connected.
       const applyAttribute = (attr, value) => {
         const prop = attributePropMap.get(attr) ?? attr
-        this.svelteProps[prop] = boolProperties.has(prop) ? value !== null : value
+        this.svelteProps[prop] = isBooleanProperty(prop, value) ? value !== null : value
       }
 
       new MutationObserver(m => {


### PR DESCRIPTION
@petemill I've done a bit of performance testing and it doesn't look like there's much effect (if any). After even looks marginally faster, but I'm hesitant to trust it:

### After this PR (100000 iterations)

Create/Destroy took 2398
Change Props took 5232
Change Attributes took 6932
Change Slots took 5232

### Before this PR (100000 iterations)
Create/Destroy took 2578
Change Props took 6082
Change Attributes took 6512
Change Slots took 5473

**Note:** I ran these tests again a bit later, and about 3 seconds were added to each test - think my laptop started thermally throttling :laughing: 