### PR TITLE
[Input]: Remove unused import

### DIFF
--- a/src/components/input/input.svelte
+++ b/src/components/input/input.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { ChangeEventHandler, SvelteHTMLElements } from 'svelte/elements'
+  import type { SvelteHTMLElements } from 'svelte/elements'
   import Button from '../button/button.svelte'
   import FormItem, { type Mode, type Size } from '../formItem/formItem.svelte'
   import Icon from '../icon/icon.svelte'


### PR DESCRIPTION
Removes unused import of `ChangeEventHandler`, noticed it in my linter.