### PR TITLE
[Input]: Add an explicit placeholder

### DIFF
--- a/src/components/input/input.svelte
+++ b/src/components/input/input.svelte
@@ -70,6 +70,11 @@
    */
   export let mode: Mode | undefined = undefined
 
+  /**
+   * Placeholder text for the input.
+   */
+  export let placeholder = ''
+
   type InputEventDetail = {
     innerEvent: Event & { target: HTMLInputElement }
     value: string
@@ -131,6 +136,7 @@
       {disabled}
       {type}
       {value}
+      {placeholder}
       bind:this={input}
       on:change={forwardEvent}
       on:input={onInput}


### PR DESCRIPTION
This fixes the issue where react/web component consumers can't set the placeholder text.