### PR TITLE
[Focus]: Set delegatesFocus on all components

### DIFF
--- a/src/components/svelte-web.ts
+++ b/src/components/svelte-web.ts
@@ -117,7 +117,8 @@ export default function registerWebComponent(
       // especially when being rendered inside a Polymer dom-if. In this case,
       // we need to also clear the contents of the node, to ensure we don't
       // duplicate content.
-      const shadow = this.shadowRoot ?? this.attachShadow({ mode })
+      const shadow =
+        this.shadowRoot ?? this.attachShadow({ mode, delegatesFocus: true })
       shadow.replaceChildren()
 
       let lastSlots = new Set()


### PR DESCRIPTION
This delegates the focus to the first focusable element (or the element with `autofocus`) inside the shadowDOM when `.focus()` is called on the element.

I don't know if we want this for every component, but it does seem like a sensible default.

https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/delegatesFocus