### PR TITLE
Enable autodocs for Storybook

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -21,7 +21,7 @@ export default {
   },
   framework: { name: '@storybook/svelte-vite' },
   docs: {
-    autodocs: true,
+    autodocs: true
   },
   staticDirs: [
     {

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -20,6 +20,9 @@ export default {
     disableTelemetry: true
   },
   framework: { name: '@storybook/svelte-vite' },
+  docs: {
+    autodocs: true,
+  },
   staticDirs: [
     {
       from: '../icons',


### PR DESCRIPTION
While not perfect (mainly referring to the `Source code` view not working properly), I think docs are a helpful way to quickly survey the component stories, and to easily surface/link to the props.
