### PR TITLE
Add RTL support in Toggle and NavDots

### DIFF
--- a/src/components/navdots/navdots.svelte
+++ b/src/components/navdots/navdots.svelte
@@ -44,6 +44,14 @@
 </nav>
 
 <style lang="scss">
+  :global(:root) {
+    --leo-direction: 1;
+  }
+
+  :global(:root[dir=rtl]) {
+    --leo-direction: -1;
+  }
+
   :host {
     display: block;
   }
@@ -134,8 +142,8 @@
         box-shadow var(--transition-duration) var(--transition-easing);
       transform: translate(
         calc(
-          (var(--dot-size) + var(--dot-spacing)) * var(--current-dot) -
-            var(--dot-spacing) / 2
+          ((var(--dot-size) + var(--dot-spacing)) * var(--current-dot) -
+            var(--dot-spacing) / 2) * var(--leo-direction)
         ),
         0
       );

--- a/src/components/toggle/toggle.svelte
+++ b/src/components/toggle/toggle.svelte
@@ -49,6 +49,8 @@
   on:mousemove={(e) => {
     if (dragStartX === undefined) return
     dragOffsetX = e.clientX - dragStartX
+
+    if (document.documentElement.dir === 'rtl') dragOffsetX = -dragOffsetX
   }}
 />
 
@@ -88,6 +90,14 @@
 </label>
 
 <style lang="scss">
+  :global(:root) {
+    --leo-direction: 1;
+  }
+
+  :global(:root[dir=rtl]) {
+    --leo-direction: -1;
+  }
+
   :host {
     display: inline-block;
   }
@@ -178,13 +188,13 @@
       --checked-thumb-offset: calc(var(--width) - var(--height));
       --thumb-offset: var(--unchecked-thumb-offset);
       --drag-offset: 0;
-      --thumb-position: max(
+      --thumb-position: calc(max(
         min(
           var(--checked-thumb-offset),
           calc(var(--thumb-offset) + var(--drag-offset))
         ),
         var(--unchecked-thumb-offset)
-      );
+      ) * var(--leo-direction));
 
       height: 100%;
       aspect-ratio: 1/1;


### PR DESCRIPTION
Currently, the Navdots and Toggle do some calculations with CSS properties which don't play nice with RTL. This fixes them.