### PR TITLE
[Svelte]: Fix missed events

### DIFF
--- a/src/components/alert/alert.stories.svelte
+++ b/src/components/alert/alert.stories.svelte
@@ -157,7 +157,7 @@
     <input type="checkbox" bind:checked={hasAction} />
   </label>
   <Button
-    on:click={() => {
+    onClick={() => {
       alertUser(args.mode, args.type)
     }}>Show Alert</Button
   >

--- a/src/components/alert/alertCenter.svelte
+++ b/src/components/alert/alertCenter.svelte
@@ -101,7 +101,7 @@
         </div>
         <svelte:fragment slot='content-after'>
           {#if alert.canDismiss}
-            <Button kind="plain-faint" fab on:click={() => alert.dismiss()}>
+            <Button kind="plain-faint" fab onClick={() => alert.dismiss()}>
               <Icon name="close" />
             </Button>
           {/if}
@@ -113,7 +113,7 @@
               size={alert.mode === "full" ? "medium" : "small"}
               fab={action.icon && !action.text}
               kind={action.kind || 'filled'}
-              on:click={() => action.action(alert)}
+              onClick={() => action.action(alert)}
             >
               {#if action.icon && !action.text}
                 <Icon name={action.icon} />

--- a/src/components/button/button.stories.svelte
+++ b/src/components/button/button.stories.svelte
@@ -37,7 +37,7 @@
 />
 
 <Template let:args>
-  <Button {...args} on:click={handleClick}>
+  <Button {...args} onClick={handleClick}>
     You clicked: {count}
   </Button>
 </Template>

--- a/src/components/buttonMenu/buttonMenu.svelte
+++ b/src/components/buttonMenu/buttonMenu.svelte
@@ -42,7 +42,6 @@
   <Menu
     bind:isOpen
     target={anchor}
-    on:click={toggle}
     onClose={onClose}
   >
     <slot />

--- a/src/components/dialog/dialog.stories.svelte
+++ b/src/components/dialog/dialog.stories.svelte
@@ -52,7 +52,7 @@
 />
 
 <Template let:args>
-  <Button isDisabled={isOpen} on:click={() => (isOpen = true)}
+  <Button isDisabled={isOpen} onClick={() => (isOpen = true)}
     >Show Dialog</Button
   >
   <Dialog {...args} bind:isOpen>
@@ -80,45 +80,45 @@
 <Story name="Slots" let:args>
   <SlotInfo description="The dialog supports several slots">
     <Slot name="default" explanation="The content of the dialog">
-      <Button on:click={() => (openDialog = 'default')}>Show Dialog</Button>
+      <Button onClick={() => (openDialog = 'default')}>Show Dialog</Button>
       <Dialog
         {...args}
         isOpen={openDialog === 'default'}
-        on:close={() => (openDialog = undefined)}
+        onClose={() => (openDialog = undefined)}
       >
         This is the dialog content
       </Dialog>
     </Slot>
     <Slot name="title" explanation="The title of the dialog">
-      <Button on:click={() => (openDialog = 'title')}>Show Title Dialog</Button>
+      <Button onClick={() => (openDialog = 'title')}>Show Title Dialog</Button>
       <Dialog
         {...args}
         isOpen={openDialog === 'title'}
-        on:close={() => (openDialog = undefined)}
+        onClose={() => (openDialog = undefined)}
       >
         <div slot="title">Dialog Title</div>
       </Dialog>
     </Slot>
     <Slot name="subtitle" explanation="The subtitle of the dialog">
-      <Button on:click={() => (openDialog = 'subtitle')}
+      <Button onClick={() => (openDialog = 'subtitle')}
         >Show Subtitle Dialog</Button
       >
       <Dialog
         {...args}
         isOpen={openDialog === 'subtitle'}
-        on:close={() => (openDialog = undefined)}
+        onClose={() => (openDialog = undefined)}
       >
         <div slot="subtitle">Dialog Subtitle</div>
       </Dialog>
     </Slot>
     <Slot name="actions" explanation="The actions for the dialog">
-      <Button on:click={() => (openDialog = 'actions')}
+      <Button onClick={() => (openDialog = 'actions')}
         >Show Actions Dialog</Button
       >
       <Dialog
         {...args}
         isOpen={openDialog === 'actions'}
-        on:close={() => (openDialog = undefined)}
+        onClose={() => (openDialog = undefined)}
       >
         Dialog body
         <div slot="actions">

--- a/src/components/dialog/dialog.svelte
+++ b/src/components/dialog/dialog.svelte
@@ -65,7 +65,7 @@
   >
     {#if showClose}
       <div class="close-button">
-        <Button kind="plain-faint" on:click={close}>
+        <Button kind="plain-faint" onClick={close}>
           <Icon name="close" />
         </Button>
       </div>
@@ -76,7 +76,7 @@
           <div class="title-row">
             {#if showBack}
               <div class="back-button">
-                <Button kind="plain-faint" on:click={onBack}>
+                <Button kind="plain-faint" onClick={onBack}>
                   <Icon name="arrow-left" />
                 </Button>
               </div>

--- a/src/components/dialog/dialogsContainer.svelte
+++ b/src/components/dialog/dialogsContainer.svelte
@@ -5,7 +5,7 @@
 </script>
 
 {#each $dialogs as dialog}
-  <Dialog modal isOpen on:close={() => dialog.resolve()}>
+  <Dialog modal isOpen onClose={() => dialog.resolve()}>
     <div slot="title">{dialog.title}</div>
     {#if dialog.body}
       <div>{dialog.body}</div>
@@ -14,7 +14,7 @@
       {#each dialog.actions as action}
         <Button
           kind={action.kind}
-          on:click={() => dialog.resolve(action.result)}
+          onClick={() => dialog.resolve(action.result)}
         >
           {action.text}
         </Button>

--- a/src/components/input/input.svelte
+++ b/src/components/input/input.svelte
@@ -170,7 +170,7 @@
   </div>
   <slot name="right-icon" slot="right-icon">
     {#if pickerIcons[type]}
-      <Button kind="plain-faint" on:click={() => input?.showPicker()}>
+      <Button kind="plain-faint" onClick={() => input?.showPicker()}>
         <Icon name={pickerIcons[type]} />
       </Button>
     {/if}

--- a/src/components/navdots/navdots.stories.svelte
+++ b/src/components/navdots/navdots.stories.svelte
@@ -63,7 +63,7 @@
 />
 
 <Template let:args>
-  <NavDots {activeDot} on:change={handleChange} {...args} />
+  <NavDots {activeDot} onChange={handleChange} {...args} />
 </Template>
 
 <Story name="Slots">

--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -51,12 +51,17 @@ module.exports = {
    * Returns the paths to all Svelte files in a directory (and subdirectories).
    * @param {string} root The root folder
    * @param {boolean} includeDts Whether to include typescript definition files
+   * @param {boolean} includeStories Whether to include stories
    */
-  getSvelteFiles: async function* (root, includeDts = true) {
+  getSvelteFiles: async function* (
+    root,
+    includeDts = true,
+    includeStories = false
+  ) {
     for await (const file of await walk(root)) {
       if (
         !file.includes('.svelte') ||
-        file.includes('.stories.svelte') ||
+        (!includeStories && file.includes('.stories.svelte')) ||
         (!includeDts && file.endsWith('.d.ts'))
       )
         continue


### PR DESCRIPTION
Followup to #600 

I missed some internal usages of the old style events (which obviously Typescript doesn't catch because svelte is fine with any `on:` events being added to components.

Wrote a script to find accidental usages and added it to presubmit.