### PR TITLE
[FormItem]: fix bad selector inadvertently hiding label

### DIFF
--- a/examples/example-ui-react/src/App.tsx
+++ b/examples/example-ui-react/src/App.tsx
@@ -21,10 +21,9 @@ function App() {
     <div className={styles['App']} data-theme="dark">
       <header className={styles['App-header']}>
         <h1>A React App</h1>
-        <label>
+        <Input value={buttonText} onInput={(e: any) => setButtonText(e.value)}>
           Edit the button text:
-          <Input value={buttonText} onInput={(e) => setButtonText(e.value)} />
-        </label>
+        </Input>
         {buttonText && (
           <LeoButton
             className={spinning ? 'spin' : ''}

--- a/src/components/formItem/formItem.svelte
+++ b/src/components/formItem/formItem.svelte
@@ -247,7 +247,7 @@
     flex-direction: row;
     gap: var(--leo-spacing-s);
 
-    &:empty, &:has(slot:empty) {
+    &:empty, &:has(::slotted(*):empty) {
       display: none;
     }
   }


### PR DESCRIPTION
From [a little peaking online](https://github.com/w3c/csswg-drafts/issues/6867), it doesn't seem as though it's entirely possible yet to select empty slots.

I'm also not sure it's entirely necessary since there's no slot added if the component has no children. I did, however, replace it with a selector which I believe accomplishes the intent of the other selector (an element passed as a child, but without content), and seems to work.
