### PR TITLE
[Events]: Allow event handler objects

### DIFF
--- a/src/components/svelte-web.ts
+++ b/src/components/svelte-web.ts
@@ -254,16 +254,20 @@ export default function registerWebComponent(
 
     addEventListener(
       event: string,
-      callback: Callback,
+      eventHandler: EventListenerOrEventListenerObject,
       options?: boolean | AddEventListenerOptions
     ) {
       const svelteEvent = events[event]
       if (svelteEvent) {
+        const callback =
+          'handleEvent' in eventHandler
+            ? eventHandler.handleEvent.bind(eventHandler)
+            : eventHandler
         this[svelteEvent] = callback
         return
       }
 
-      super.addEventListener(event, callback, options)
+      super.addEventListener(event, eventHandler, options)
     }
 
     removeEventListener(


### PR DESCRIPTION
I didn't realise this was a thing you could do, but if you pass an object with a `handleEvent` function, that will be invoked!

This is what `LitElement` does, so we won't work with LitElement until we fix this.