### PR TITLE
[Checkbox]: Fix how handler is called

### DIFF
--- a/src/components/checkbox/checkbox.svelte
+++ b/src/components/checkbox/checkbox.svelte
@@ -21,10 +21,6 @@
   export let size: Sizes = 'normal'
 
   export let onChange: (detail: { checked: boolean }) => void = undefined
-
-  function change(e) {
-    onChange?.(e.target.checked)
-  }
 </script>
 
 <label
@@ -38,7 +34,7 @@
       disabled={isDisabled}
       type="checkbox"
       bind:checked
-      on:change={change}
+      on:change={(e) => onChange?.({ checked: e.currentTarget.checked })}
     />
     {#if checked}
       <div transition:fade={fadeTransition}>


### PR DESCRIPTION
Not sure how this passed type checking - I guess this passed typechecking because `e` has the any type.