### PR TITLE
[FormItem]: Conditionally render label slot

### DIFF
--- a/src/components/dropdown/dropdown.svelte
+++ b/src/components/dropdown/dropdown.svelte
@@ -51,6 +51,7 @@
       bind:required
       bind:size
       bind:controlElement={dropdown}
+      renderLabel={$$slots.default}
       {mode}
       showFocusOutline={isOpen}
       error={showErrors && $$slots.errors}

--- a/src/components/formItem/formItem.svelte
+++ b/src/components/formItem/formItem.svelte
@@ -65,6 +65,10 @@
   export let showFocusOutline: boolean = false
   export let error = false
 
+  // Unfortunately, we can't conditionally render slots in Svelte, so we provide
+  // a flag so the consumer can let us know if they're actually setting a label.
+  export let renderLabel: boolean
+
   export let controlElement: HTMLDivElement = undefined
 </script>
 
@@ -78,7 +82,7 @@
   class:error
   aria-disabled={disabled}
 >
-  {#if $$slots.label}
+  {#if $$slots.label && renderLabel}
     <div class="label-row">
       <slot name="label" />{#if required}<span class="required-indicator">*</span>{/if}
     </div>
@@ -246,10 +250,6 @@
     display: flex;
     flex-direction: row;
     gap: var(--leo-spacing-s);
-
-    &:empty, &:has(::slotted(*):empty) {
-      display: none;
-    }
   }
 
   .leo-control .required-indicator {

--- a/src/components/input/input.svelte
+++ b/src/components/input/input.svelte
@@ -138,6 +138,7 @@
 <FormItem
   bind:required
   bind:disabled
+  renderLabel={$$slots.default}
   {size}
   {mode}
   error={($$slots.errors || hasErrorsInternal) && showErrors}


### PR DESCRIPTION
As is traditional, our fix for `FormItems` not rendering labels broke by making `FormItems` with no label render a label.

This passes through from the consumer whether a label has been set, which will hopefully put the issue to bed.