### PR TITLE
more button fixes

### DIFF
--- a/src/components/button/button.svelte
+++ b/src/components/button/button.svelte
@@ -157,6 +157,15 @@
     .content {
       padding: 0 var(--icon-gap);
     }
+
+    /*
+     * Should only be necessary for Tailwind consumers where there's
+     * no guarantee that the button will contain a child element.
+     */
+    &:not(:has(> *)) {
+      padding-left: var(--leo-button-padding, calc(var(--padding-x) + var(--icon-gap)));
+      padding-right: var(--leo-button-padding, calc(var(--padding-x) + var(--icon-gap)));
+    }
   }
 
   .leoButton:not(:disabled) {

--- a/src/components/button/button.svelte
+++ b/src/components/button/button.svelte
@@ -147,7 +147,7 @@
     background: var(--bg);
     color: var(--color);
     text-decoration: none;
-    padding: var(--leo-button-padding, var(--padding-y) var(--padding-x));
+    padding: var(--leo-button-padding, calc(var(--padding-y) - var(--border-width)) var(--padding-x));
     max-height: max-content;
 
     &.fab {

--- a/src/scripts/gen-android-icons.js
+++ b/src/scripts/gen-android-icons.js
@@ -18,7 +18,6 @@ fs.mkdir(OUTPUT_FOLDER, { recursive: true })
           .basename(icon, '.svg')
           .replaceAll('-', '_')}.xml`
         fs.writeFile(path.join(OUTPUT_FOLDER, outputFileName), vectorContent)
-        console.log(outputFileName)
       })
     })
   )


### PR DESCRIPTION
- **[Meta]: removes console log in android icon generation**
- **[Button]: fix button height consistency**
- **[Button]: ensure proper padding when contents is only a text node**
    This is important for Tailwind consumers since a class is applied to elements without necessarily wrapping contents in an element with `.content` as would happen when using as a JS component.
