### PR TITLE
[Input]: Placeholder color should follow text color

### DIFF
--- a/src/components/input/input.svelte
+++ b/src/components/input/input.svelte
@@ -193,6 +193,11 @@
     flex: 1;
   }
 
+  .leo-input::placeholder {
+    color: currentColor;
+    opacity: 0.6;
+  }
+
   .input-container {
     flex: 1;
 


### PR DESCRIPTION
The opacity value was chosen because it looks pretty similar for our existing dark/light mode. This means if you override the text color, the placeholder color will fit right in.

Needed for the NTP Search project.