### PR TITLE
[Icon]: Add support for libraries of icons

### DIFF
--- a/src/components/icon/icon.stories.svelte
+++ b/src/components/icon/icon.stories.svelte
@@ -46,6 +46,11 @@
       description:
         'The current text color (this is used for the icon if --leo-icon-color is not set)',
       type: 'string'
+    },
+    library: {
+      control:'text',
+      description: 'The library this icon belongs to',
+      type: 'string'
     }
   }}
   args={{

--- a/src/components/icon/icon.svelte
+++ b/src/components/icon/icon.svelte
@@ -3,12 +3,22 @@
   import { writable } from 'svelte/store'
 
   let lastIconBasePath = '/icons'
-  let iconBasePath = writable(lastIconBasePath)
+  let iconBasePath = writable<{
+    [key: string]: string
+  }>({
+    '': lastIconBasePath
+  })
 
   export const setIconBasePath = (basePath: string) => {
     lastIconBasePath = basePath
-    iconBasePath.set(basePath)
+    addLibrary('', basePath)
   }
+
+  export const addLibrary = (library: string, basePath: string) =>
+    iconBasePath.update((prev) => ({
+      ...prev,
+      [library]: basePath
+    }))
 
   const getIconUrl = (basePath: string, name: string) =>
     `${basePath}/${name}.svg`
@@ -38,8 +48,11 @@
   export let name: IconName = undefined
   export let forceColor: boolean = false
   export let title: string = undefined
+  export let library: string = ''
+
   $: hasColor =
     name?.endsWith('-color') || name?.startsWith('country-') || forceColor
+  $: basePath = $iconBasePath[library || ''] ?? ''
 </script>
 
 <div class="leoIcon" {title}>
@@ -48,7 +61,7 @@
       <div
         class="icon"
         class:color={hasColor}
-        style:--icon-url={`url('${getIconUrl($iconBasePath, name)}')`}
+        style:--icon-url={`url('${getIconUrl(basePath, name)}')`}
       />
     {/if}
   </slot>


### PR DESCRIPTION
The motivation for this is I need to be able to display Chromium icons from `chrome://resources/images/*` on the NTP alongside Nala icons.

Previously, I was just displaying the icon via an `<img src="..."/>`. However, when I do this, I can't change to color. Fortunately, Nala supports letting me do this sort of thing already, so if I can add an Icon library for the upstream icons, this should work nicely :smile: