### PR TITLE
[Storybook]: ensures layer tokens are only loaded when viewing story

### DIFF
--- a/.storybook/global.svelte
+++ b/.storybook/global.svelte
@@ -1,3 +1,22 @@
+<script context="module" lang="ts">
+  export function scopedApplyLayer(name: string) {
+    let ss: CSSStyleSheet
+    fetch(`/css/${name}.css`)
+      .then((r) => r.text())
+      .then((css) => {
+        ss = new CSSStyleSheet()
+        ss.replaceSync(css)
+        document.adoptedStyleSheets.push(ss)
+      })
+
+    return () => {
+      document.adoptedStyleSheets = document.adoptedStyleSheets.filter(
+        (s) => s !== ss
+      )
+    }
+  }
+</script>
+
 <script lang="ts">
   import AlertCenter from '../src/components/alert/alertCenter.svelte'
   import ControlItem from '../src/components/controlItem/controlItem.svelte'
@@ -19,7 +38,7 @@
 
 <div class="layout" data-theme={theme}>
   <div class="theme-toggle-container">
-    <SegmentedControl size='tiny' bind:value={theme}>
+    <SegmentedControl size="tiny" bind:value={theme}>
       <ControlItem value="light">
         <Icon name="theme-light" />
       </ControlItem>

--- a/src/tokens/browserFontTokens.stories.svelte
+++ b/src/tokens/browserFontTokens.stories.svelte
@@ -1,8 +1,18 @@
 <script lang="ts">
+  import { onMount } from 'svelte'
   import { Meta, Story } from '@storybook/addon-svelte-csf'
   import { font as allFonts } from '../../tokens/css/variables-browser'
   import FontTokenSwatchGroup from '../storyHelpers/FontTokenSwatchGroup.svelte'
-  import '../../tokens/css/variables-browser.css'
+  // @ts-ignore
+  import styles from '../../tokens/css/variables-browser.css?raw'
+
+  onMount(() => {
+    const stylesheet = new CSSStyleSheet();
+    stylesheet.replaceSync(styles);
+    document.adoptedStyleSheets = [stylesheet];
+
+    return () => document.adoptedStyleSheets = [];
+  })
 </script>
 
 <Meta title="Tokens/Browser/Fonts" />

--- a/src/tokens/browserFontTokens.stories.svelte
+++ b/src/tokens/browserFontTokens.stories.svelte
@@ -3,16 +3,9 @@
   import { Meta, Story } from '@storybook/addon-svelte-csf'
   import { font as allFonts } from '../../tokens/css/variables-browser'
   import FontTokenSwatchGroup from '../storyHelpers/FontTokenSwatchGroup.svelte'
-  // @ts-ignore
-  import styles from '../../tokens/css/variables-browser.css?raw'
+  import { scopedApplyLayer } from '../../.storybook/global.svelte'
 
-  onMount(() => {
-    const stylesheet = new CSSStyleSheet();
-    stylesheet.replaceSync(styles);
-    document.adoptedStyleSheets = [stylesheet];
-
-    return () => document.adoptedStyleSheets = [];
-  })
+  onMount(() => scopedApplyLayer("variables-browser"))
 </script>
 
 <Meta title="Tokens/Browser/Fonts" />

--- a/src/tokens/marketingFontTokens.stories.svelte
+++ b/src/tokens/marketingFontTokens.stories.svelte
@@ -3,16 +3,9 @@
   import { Meta, Story } from '@storybook/addon-svelte-csf'
   import { font as allFonts } from '../../tokens/css/variables-marketing'
   import FontTokenSwatchGroup from '../storyHelpers/FontTokenSwatchGroup.svelte'
-  // @ts-ignore
-  import styles from '../../tokens/css/variables-marketing.css?raw'
+  import { scopedApplyLayer } from '../../.storybook/global.svelte'
 
-  onMount(() => {
-    const stylesheet = new CSSStyleSheet();
-    stylesheet.replaceSync(styles);
-    document.adoptedStyleSheets = [stylesheet];
-
-    return () => document.adoptedStyleSheets = [];
-  })
+  onMount(() => scopedApplyLayer("variables-marketing"))
 
   const { mobile, desktop } = allFonts
 </script>

--- a/src/tokens/marketingFontTokens.stories.svelte
+++ b/src/tokens/marketingFontTokens.stories.svelte
@@ -1,8 +1,18 @@
 <script lang="ts">
+  import { onMount } from 'svelte'
   import { Meta, Story } from '@storybook/addon-svelte-csf'
   import { font as allFonts } from '../../tokens/css/variables-marketing'
   import FontTokenSwatchGroup from '../storyHelpers/FontTokenSwatchGroup.svelte'
-  import '../../tokens/css/variables-marketing.css'
+  // @ts-ignore
+  import styles from '../../tokens/css/variables-marketing.css?raw'
+
+  onMount(() => {
+    const stylesheet = new CSSStyleSheet();
+    stylesheet.replaceSync(styles);
+    document.adoptedStyleSheets = [stylesheet];
+
+    return () => document.adoptedStyleSheets = [];
+  })
 
   const { mobile, desktop } = allFonts
 </script>

--- a/src/tokens/newsGradientTokens.stories.svelte
+++ b/src/tokens/newsGradientTokens.stories.svelte
@@ -3,16 +3,9 @@
   import { Meta, Story } from '@storybook/addon-svelte-csf'
   import { gradient as allGradients } from '../../tokens/css/variables-news'
   import ColorTokenSwatchGroup from '../storyHelpers/ColorTokenSwatchGroup.svelte'
-  // @ts-ignore
-  import styles from '../../tokens/css/variables-news.css?raw'
+  import { scopedApplyLayer } from '../../.storybook/global.svelte'
 
-  onMount(() => {
-    const stylesheet = new CSSStyleSheet();
-    stylesheet.replaceSync(styles);
-    document.adoptedStyleSheets = [stylesheet];
-
-    return () => document.adoptedStyleSheets = [];
-  })
+  onMount(() => scopedApplyLayer("variables-news"))
 </script>
 
 <Meta title="Tokens/News/Gradients" />

--- a/src/tokens/newsGradientTokens.stories.svelte
+++ b/src/tokens/newsGradientTokens.stories.svelte
@@ -1,8 +1,18 @@
 <script lang="ts">
+  import { onMount } from 'svelte'
   import { Meta, Story } from '@storybook/addon-svelte-csf'
   import { gradient as allGradients } from '../../tokens/css/variables-news'
   import ColorTokenSwatchGroup from '../storyHelpers/ColorTokenSwatchGroup.svelte'
-  import '../../tokens/css/variables-news.css'
+  // @ts-ignore
+  import styles from '../../tokens/css/variables-news.css?raw'
+
+  onMount(() => {
+    const stylesheet = new CSSStyleSheet();
+    stylesheet.replaceSync(styles);
+    document.adoptedStyleSheets = [stylesheet];
+
+    return () => document.adoptedStyleSheets = [];
+  })
 </script>
 
 <Meta title="Tokens/News/Gradients" />

--- a/src/tokens/newtabFontTokens.stories.svelte
+++ b/src/tokens/newtabFontTokens.stories.svelte
@@ -1,8 +1,18 @@
 <script lang="ts">
+  import { onMount } from 'svelte'
   import { Meta, Story } from '@storybook/addon-svelte-csf'
   import { font as allFonts } from '../../tokens/css/variables-newtab'
   import FontTokenSwatchGroup from '../storyHelpers/FontTokenSwatchGroup.svelte'
-  import '../../tokens/css/variables-newtab.css'
+  // @ts-ignore
+  import styles from '../../tokens/css/variables-newtab.css?raw'
+
+  onMount(() => {
+    const stylesheet = new CSSStyleSheet();
+    stylesheet.replaceSync(styles);
+    document.adoptedStyleSheets = [stylesheet];
+
+    return () => document.adoptedStyleSheets = [];
+  })
 </script>
 
 <Meta title="Tokens/New Tab/Fonts" />

--- a/src/tokens/newtabFontTokens.stories.svelte
+++ b/src/tokens/newtabFontTokens.stories.svelte
@@ -3,16 +3,9 @@
   import { Meta, Story } from '@storybook/addon-svelte-csf'
   import { font as allFonts } from '../../tokens/css/variables-newtab'
   import FontTokenSwatchGroup from '../storyHelpers/FontTokenSwatchGroup.svelte'
-  // @ts-ignore
-  import styles from '../../tokens/css/variables-newtab.css?raw'
+  import { scopedApplyLayer } from '../../.storybook/global.svelte'
 
-  onMount(() => {
-    const stylesheet = new CSSStyleSheet();
-    stylesheet.replaceSync(styles);
-    document.adoptedStyleSheets = [stylesheet];
-
-    return () => document.adoptedStyleSheets = [];
-  })
+  onMount(() => scopedApplyLayer("variables-newtab"))
 </script>
 
 <Meta title="Tokens/New Tab/Fonts" />

--- a/src/tokens/newtabGradientTokens.stories.svelte
+++ b/src/tokens/newtabGradientTokens.stories.svelte
@@ -1,8 +1,18 @@
 <script lang="ts">
+  import { onMount } from 'svelte'
   import { Meta, Story } from '@storybook/addon-svelte-csf'
   import { gradient as allGradients } from '../../tokens/css/variables-newtab'
   import ColorTokenSwatchGroup from '../storyHelpers/ColorTokenSwatchGroup.svelte'
-  import '../../tokens/css/variables-newtab.css'
+  // @ts-ignore
+  import styles from '../../tokens/css/variables-newtab.css?raw'
+
+  onMount(() => {
+    const stylesheet = new CSSStyleSheet();
+    stylesheet.replaceSync(styles);
+    document.adoptedStyleSheets = [stylesheet];
+
+    return () => document.adoptedStyleSheets = [];
+  })
 </script>
 
 <Meta title="Tokens/New Tab/Gradients" />

--- a/src/tokens/newtabGradientTokens.stories.svelte
+++ b/src/tokens/newtabGradientTokens.stories.svelte
@@ -3,16 +3,9 @@
   import { Meta, Story } from '@storybook/addon-svelte-csf'
   import { gradient as allGradients } from '../../tokens/css/variables-newtab'
   import ColorTokenSwatchGroup from '../storyHelpers/ColorTokenSwatchGroup.svelte'
-  // @ts-ignore
-  import styles from '../../tokens/css/variables-newtab.css?raw'
+  import { scopedApplyLayer } from '../../.storybook/global.svelte'
 
-  onMount(() => {
-    const stylesheet = new CSSStyleSheet();
-    stylesheet.replaceSync(styles);
-    document.adoptedStyleSheets = [stylesheet];
-
-    return () => document.adoptedStyleSheets = [];
-  })
+  onMount(() => scopedApplyLayer("variables-newtab"))
 </script>
 
 <Meta title="Tokens/New Tab/Gradients" />

--- a/src/tokens/searchFontTokens.stories.svelte
+++ b/src/tokens/searchFontTokens.stories.svelte
@@ -3,16 +3,9 @@
   import { Meta, Story } from '@storybook/addon-svelte-csf'
   import { font as allFonts } from '../../tokens/css/variables-search'
   import FontTokenSwatchGroup from '../storyHelpers/FontTokenSwatchGroup.svelte'
-  // @ts-ignore
-  import styles from '../../tokens/css/variables-search.css?raw'
+  import { scopedApplyLayer } from '../../.storybook/global.svelte'
 
-  onMount(() => {
-    const stylesheet = new CSSStyleSheet();
-    stylesheet.replaceSync(styles);
-    document.adoptedStyleSheets = [stylesheet];
-
-    return () => document.adoptedStyleSheets = [];
-  })
+  onMount(() => scopedApplyLayer("variables-search"))
 </script>
 
 <Meta title="Tokens/Search/Fonts" />

--- a/src/tokens/searchFontTokens.stories.svelte
+++ b/src/tokens/searchFontTokens.stories.svelte
@@ -1,8 +1,18 @@
 <script lang="ts">
+  import { onMount } from 'svelte'
   import { Meta, Story } from '@storybook/addon-svelte-csf'
   import { font as allFonts } from '../../tokens/css/variables-search'
   import FontTokenSwatchGroup from '../storyHelpers/FontTokenSwatchGroup.svelte'
-  import '../../tokens/css/variables-search.css'
+  // @ts-ignore
+  import styles from '../../tokens/css/variables-search.css?raw'
+
+  onMount(() => {
+    const stylesheet = new CSSStyleSheet();
+    stylesheet.replaceSync(styles);
+    document.adoptedStyleSheets = [stylesheet];
+
+    return () => document.adoptedStyleSheets = [];
+  })
 </script>
 
 <Meta title="Tokens/Search/Fonts" />

--- a/src/tokens/searchGradientTokens.stories.svelte
+++ b/src/tokens/searchGradientTokens.stories.svelte
@@ -1,8 +1,18 @@
 <script lang="ts">
+  import { onMount } from 'svelte'
   import { Meta, Story } from '@storybook/addon-svelte-csf'
   import { gradient as allGradients } from '../../tokens/css/variables-search'
   import ColorTokenSwatchGroup from '../storyHelpers/ColorTokenSwatchGroup.svelte'
-  import '../../tokens/css/variables-search.css'
+  // @ts-ignore
+  import styles from '../../tokens/css/variables-search.css?raw'
+
+  onMount(() => {
+    const stylesheet = new CSSStyleSheet();
+    stylesheet.replaceSync(styles);
+    document.adoptedStyleSheets = [stylesheet];
+
+    return () => document.adoptedStyleSheets = [];
+  })
 </script>
 
 <Meta title="Tokens/Search/Gradients" />

--- a/src/tokens/searchGradientTokens.stories.svelte
+++ b/src/tokens/searchGradientTokens.stories.svelte
@@ -3,16 +3,9 @@
   import { Meta, Story } from '@storybook/addon-svelte-csf'
   import { gradient as allGradients } from '../../tokens/css/variables-search'
   import ColorTokenSwatchGroup from '../storyHelpers/ColorTokenSwatchGroup.svelte'
-  // @ts-ignore
-  import styles from '../../tokens/css/variables-search.css?raw'
+  import { scopedApplyLayer } from '../../.storybook/global.svelte'
 
-  onMount(() => {
-    const stylesheet = new CSSStyleSheet();
-    stylesheet.replaceSync(styles);
-    document.adoptedStyleSheets = [stylesheet];
-
-    return () => document.adoptedStyleSheets = [];
-  })
+  onMount(() => scopedApplyLayer("variables-search"))
 </script>
 
 <Meta title="Tokens/Search/Gradients" />


### PR DESCRIPTION
Prior to this PR, tokens that get overriden by other layers were not accurately being displayed in Storyook. See for example font tokens for `Browser`.
