### PR TITLE
[Tokens](Tailwind): fixes color references in shadows

### DIFF
--- a/src/tokens/transformation/tailwind/twShadows.js
+++ b/src/tokens/transformation/tailwind/twShadows.js
@@ -14,11 +14,21 @@ module.exports = {
   }
 }
 
+/**
+ * @param {string} colorString
+ * @returns {string}
+ */
+const formatColorForTw = (colorString) => {
+  const formattedColor = formatColor('tw', colorString)
+  return colorString.startsWith('$')
+    ? `rgba(${formattedColor}, 1)`
+    : formattedColor
+}
+
 function formatBoxShadow(value) {
   return `${value.shadowType === 'innerShadow' ? 'inset ' : ''}${
     value.offsetX
-  }px ${value.offsetY}px ${value.radius}px ${value.spread}px ${formatColor(
-    'tw',
+  }px ${value.offsetY}px ${value.radius}px ${value.spread}px ${formatColorForTw(
     value.color
   )}`
 }
@@ -26,5 +36,5 @@ function formatBoxShadow(value) {
 function formatDropShadow(value) {
   return `${value.shadowType === 'innerShadow' ? 'inset ' : ''}${
     value.offsetX
-  }px ${value.offsetY}px ${value.radius}px ${formatColor('tw', value.color)}`
+  }px ${value.offsetY}px ${value.radius}px ${formatColorForTw(value.color)}`
 }


### PR DESCRIPTION
Since Tailwind colors need to support user defined opacities, they they are set as partials instead of a full color function (e.g. `255, 255, 255` vs `rgba(255, 255, 255, 1)`). This caused a problem with shadows like "focus-state", though, since it was referencing a partial without being wrapped in a color function.