### PR TITLE
[Dialog]: Make is possible to customize the backdrop

### DIFF
--- a/src/components/dialog/dialog.stories.svelte
+++ b/src/components/dialog/dialog.stories.svelte
@@ -38,6 +38,16 @@
       control: 'color',
       description: 'The default text color of the dialog'
     },
+    '--leo-dialog-backdrop-background': {
+      type: 'string',
+      control: 'color',
+      description: 'The color of the backdrop behind a modal dialog'
+    },
+    '--leo-dialog-backdrop-filter': {
+      type: 'string',
+      control: 'text',
+      description: 'The filter to apply to the backdrop'
+    },
     isOpen: {
       control: 'none'
     },

--- a/src/components/dialog/dialog.svelte
+++ b/src/components/dialog/dialog.svelte
@@ -130,6 +130,12 @@
     );
     --color: var(--leo-dialog-color, var(--leo-color-text-primary));
 
+    --backdrop-background: var(
+      --leo-dialog-backdrop-background,
+      rgba(0, 0, 0, 0.1)
+    );
+    --backdrop-filter: var(--leo-dialog-backdrop-filter);
+
     position: fixed;
     margin: auto;
     border: none;
@@ -144,6 +150,11 @@
 
     padding: 0;
     background: transparent;
+
+    &::backdrop {
+      background: var(--backdrop-background);
+      backdrop-filter: var(--backdrop-filter);
+    }
   }
 
   .leo-dialog.hasHeader {


### PR DESCRIPTION
This PR adds two CSS properties for customizing the backdrop:
- `--leo-dialog-backdrop-color` controls the color of the backdrop
- `--leo-dialog-backdrop-filter` controls the filter applied to the content behind the backdrop