### PR TITLE
[Dialog]: Allow title to fill width

### DIFF
--- a/src/components/dialog/dialog.svelte
+++ b/src/components/dialog/dialog.svelte
@@ -200,6 +200,8 @@
     .close-button,
     .back-button {
       --leo-button-padding: var(--leo-spacing-s);
+
+      flex: 0;
     }
   }
 
@@ -257,7 +259,7 @@
     display: flex;
     flex-direction: row;
     align-items: center;
-    justify-content: start;
+    justify-content: stretch;
     gap: var(--leo-spacing-l);
   }
 </style>


### PR DESCRIPTION
Putting `width: 100%` should cause the title to fill the available width now