### PR TITLE
[Input]: Maintain focus when creating/destroying slots

### DIFF
--- a/examples/example-ui-react/src/App.tsx
+++ b/examples/example-ui-react/src/App.tsx
@@ -23,7 +23,9 @@ function App() {
         <h1>A React App</h1>
         <Input value={buttonText} onInput={(e: any) => setButtonText(e.value)}>
           Edit the button text:
-          {buttonText.length % 2 === 0 && <Icon name='loading-spinner' slot="left-icon"/>}
+          {buttonText.length % 2 === 0 && (
+            <Icon name="loading-spinner" slot="left-icon" />
+          )}
         </Input>
         {buttonText && (
           <LeoButton

--- a/examples/example-ui-react/src/App.tsx
+++ b/examples/example-ui-react/src/App.tsx
@@ -23,6 +23,7 @@ function App() {
         <h1>A React App</h1>
         <Input value={buttonText} onInput={(e: any) => setButtonText(e.value)}>
           Edit the button text:
+          {buttonText.length % 2 === 0 && <Icon name='loading-spinner' slot="left-icon"/>}
         </Input>
         {buttonText && (
           <LeoButton

--- a/src/components/svelte-web.ts
+++ b/src/components/svelte-web.ts
@@ -55,7 +55,11 @@ const createSlot = (name?: string) => {
 const generateSelector = (el: Element) => {
   if (!el) return null
   if (el.id) return `#${el.id}`
-  return el.className.split(' ').filter(c => c).map(c => `.${c}`).join('')
+  return el.className
+    .split(' ')
+    .filter((c) => c)
+    .map((c) => `.${c}`)
+    .join('')
 }
 
 export default function registerWebComponent(
@@ -183,7 +187,7 @@ export default function registerWebComponent(
         // If there's focus within the element, get a selector to the
         // activeElement - we'll restore it after creating/destroying the
         // element.
-        const restoreFocus = generateSelector(this.shadowRoot?.activeElement);
+        const restoreFocus = generateSelector(this.shadowRoot?.activeElement)
 
         // If the component already exists, destroy it. This is,
         // unfortunately, necessary as there is no way to update slotted
@@ -216,8 +220,8 @@ export default function registerWebComponent(
         })
 
         if (restoreFocus) {
-          const restoreTo = this.shadowRoot.querySelector(restoreFocus);
-          (restoreTo as HTMLElement)?.focus?.();
+          const restoreTo = this.shadowRoot.querySelector(restoreFocus)
+          ;(restoreTo as HTMLElement)?.focus?.()
         }
       }
 

--- a/src/components/svelte-web.ts
+++ b/src/components/svelte-web.ts
@@ -45,6 +45,19 @@ const createSlot = (name?: string) => {
   }
 }
 
+/**
+ * Generate a selector for an element - note: This is pretty limited at the
+ * moment and will only work if the element has a unique id/class. However, for
+ * now this works well enough, and we can improve it easily.
+ * @param el The element to generate the selector for
+ * @returns A selector for the element: Note: This relies on the element having a unique Id or class
+ */
+const generateSelector = (el: Element) => {
+  if (!el) return null
+  if (el.id) return `#${el.id}`
+  return el.className.split(' ').filter(c => c).map(c => `.${c}`).join('')
+}
+
 export default function registerWebComponent(
   component: any,
   { name, mode }: Options
@@ -167,6 +180,11 @@ export default function registerWebComponent(
           .map((k) => [k, this[k]])
           .reduce((prev, [key, value]) => ({ ...prev, [key]: value }), {})
 
+        // If there's focus within the element, get a selector to the
+        // activeElement - we'll restore it after creating/destroying the
+        // element.
+        const restoreFocus = generateSelector(this.shadowRoot?.activeElement);
+
         // If the component already exists, destroy it. This is,
         // unfortunately, necessary as there is no way to update slotted
         // content in the output Svelte compiles to. This is a problem
@@ -196,6 +214,11 @@ export default function registerWebComponent(
             $$scope: { ctx: [] }
           }
         })
+
+        if (restoreFocus) {
+          const restoreTo = this.shadowRoot.querySelector(restoreFocus);
+          (restoreTo as HTMLElement)?.focus?.();
+        }
       }
 
       // Unfortunately we need a DOMMutationObserver to let us know when


### PR DESCRIPTION
Due to the limitations of slots in Svelte, when slots are changed the component is remounted when slots are changed. We'll never get this perfect, but maintaining focus is very useful, and makes components much easier to use.