### PR TITLE
[Input]: Make input first focused element

### DIFF
--- a/src/components/input/input.svelte
+++ b/src/components/input/input.svelte
@@ -152,6 +152,7 @@
       {type}
       {value}
       {placeholder}
+      tabindex={1}
       bind:this={input}
       on:input={handleInput}
       on:change={forward(onChange)}


### PR DESCRIPTION
Currently, if the left-icon is interactive, that will be focused before the input