### PR TITLE
[Tokens](Tailwind): Only wrap shadow colors in function if necessary

### DIFF
--- a/src/tokens/transformation/tailwind/twShadows.ts
+++ b/src/tokens/transformation/tailwind/twShadows.ts
@@ -21,7 +21,9 @@ export default {
  */
 const formatColorForTw = (colorString: string) => {
   const formattedColor = formatColor('tw', colorString)
-  return colorString.startsWith('$')
+  return colorString.startsWith('$') &&
+    !formattedColor.includes('elevation') &&
+    !formattedColor.startsWith('rgb')
     ? `rgba(${formattedColor}, 1)`
     : formattedColor
 }


### PR DESCRIPTION
The fix in https://github.com/brave/leo/pull/699 was too greedy, so this
adds additional checks to ensure that the color function isn't double
wrapped.
