### PR TITLE
[SegmentedControl]: Update styles for pill background and hover background

### DIFF
--- a/src/components/segmentedControl/segmentedControl.svelte
+++ b/src/components/segmentedControl/segmentedControl.svelte
@@ -111,7 +111,7 @@
 
   .leo-segmented-control {
     --leo-icon-size: var(--leo-icon-m);
-    --bg: var(--leo-color-gray-10);
+    --bg: var(--leo-color-neutral-10);
     --control-padding: var(--leo-control-padding, var(--leo-spacing-s));
     --gap: var(--leo-spacing-s);
     --control-height: 44px;

--- a/src/components/segmentedControl/segmentedControl.svelte
+++ b/src/components/segmentedControl/segmentedControl.svelte
@@ -111,7 +111,7 @@
 
   .leo-segmented-control {
     --leo-icon-size: var(--leo-icon-m);
-    --bg: var(--leo-color-container-highlight);
+    --bg: var(--leo-color-gray-10);
     --control-padding: var(--leo-control-padding, var(--leo-spacing-s));
     --gap: var(--leo-spacing-s);
     --control-height: 44px;
@@ -172,7 +172,7 @@
 
     :where(&:not(.transitioning)) > :global .leo-control-item:hover,
     :where(&:not(.transitioning)) > :global ::slotted(leo-controlitem:hover) {
-      --leo-control-item-background: var(--leo-color-page-background);
+      --leo-control-item-background: var(--leo-color-container-highlight);
       --leo-control-item-color: var(--leo-color-text-primary);
     }
 


### PR DESCRIPTION
There was an issue that surfaced in wallet, where the segmented control had very low contrast. I checked and it was different from figma, so here's an update

- themable/10 for component background
- container/highlight for hover state

<img width="785" alt="image" src="https://github.com/user-attachments/assets/c34d2f12-956e-4b31-bd03-89dce63468da">
