### PR TITLE
[RadioButton]: make onChange optional

### DIFF
--- a/src/components/radioButton/radioButton.svelte
+++ b/src/components/radioButton/radioButton.svelte
@@ -21,7 +21,7 @@
   export let size: Sizes = 'normal'
   export let isDisabled = false
 
-  export let onChange: (detail: { value: string | number | any }) => void
+  export let onChange: (detail: { value: string | number | any }) => void = () => {}
 
   const tagName = 'leo-radiobutton'
 


### PR DESCRIPTION
When in a Svelte consumer, sometimes it's easiest to use the `bind:value` technique instead of an `onChange` handler.