### PR TITLE
[React]: Fix latest @types/react compile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "@tsconfig/svelte": "5.0.4",
         "@types/jest": "29.5.12",
         "@types/jsdom": "21.1.7",
+        "@types/react": "18.3.5",
         "babel-loader": "9.1.3",
         "css-loader": "6.11.0",
         "css-tree": "2.3.1",
@@ -6333,9 +6334,9 @@
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
     },
     "node_modules/@types/react": {
-      "version": "18.3.3",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
-      "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.5.tgz",
+      "integrity": "sha512-WeqMfGJLGuLCqHGYRGHxnKrXcTitc6L/nBUWfWPcTarG3t9PsquqUMuVeXZeca+mglY4Vo5GZjCi0A3Or2lnxA==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@tsconfig/svelte": "5.0.4",
     "@types/jest": "29.5.12",
     "@types/jsdom": "21.1.7",
+    "@types/react": "18.3.5",
     "babel-loader": "9.1.3",
     "css-loader": "6.11.0",
     "css-tree": "2.3.1",

--- a/src/components/svelte-react.ts
+++ b/src/components/svelte-react.ts
@@ -6,7 +6,8 @@ import {
   useCallback,
   type ForwardedRef,
   type PropsWithChildren,
-  useState
+  useState,
+  type PropsWithoutRef
 } from 'react'
 import type { SvelteComponent } from 'svelte'
 
@@ -108,7 +109,10 @@ export default function SvelteWebComponentToReact<
   T extends Record<string, any>
 >(tag: string, component: typeof HTMLElement) {
   return forwardRef(
-    (props: PropsWithChildren<T>, forwardedRef: ForwardedRef<HTMLElement>) => {
+    (
+      props: PropsWithoutRef<PropsWithChildren<T>>,
+      forwardedRef: ForwardedRef<HTMLElement>
+    ) => {
       const component = useRef<HTMLElement>()
       const { setElement } = useEventHandlers(props)
 


### PR DESCRIPTION
This was breaking Brave Talk

Installing the @types/react package isn't strictly necessary for this PR but I wasn't sure where they were coming from