### PR TITLE
[Renovate]: Enable automerge for devDependencies, minor and patches

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,6 +13,11 @@
       "automerge": true
     },
     {
+      "matchUpdateTypes": ["digest"],
+      "matchRepositories": ["^brave/.*$"],
+      "automerge": true
+    },
+    {
       "matchDepTypes": ["devDependencies"],
       "automerge": true
     }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["local>brave/renovate-config"],
   "labels": ["dependencies", "renovate"],
   "prConcurrentLimit": 4,
@@ -10,6 +11,7 @@
     },
     {
       "matchUpdateTypes": ["minor", "patch", "pin"],
+      "minimumReleaseAge": "7 days",
       "automerge": true
     },
     {
@@ -19,6 +21,13 @@
     },
     {
       "matchDepTypes": ["devDependencies"],
+      "minimumReleaseAge": "7 days",
+      "automerge": true
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "enabled": true,
+      "minimumReleaseAge": "7 days",
       "automerge": true
     }
   ],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,7 +7,16 @@
     {
       "matchDepTypes": ["peerDependencies"],
       "enabled": false
+    },
+    {
+      "matchUpdateTypes": ["minor", "patch", "pin"],
+      "automerge": true
+    },
+    {
+      "matchDepTypes": ["devDependencies"],
+      "automerge": true
     }
   ],
-  "schedule": ["at 10:00am on Sunday"]
+  "schedule": ["at 10:00am on Sunday"],
+  "platformAutomerge": true
 }


### PR DESCRIPTION
I was talking to @thypon about disabling dependabot updates for `/examples/example-ui-react` or setting them to automerge and thought, why not set it for a bunch of things we normally merge anyway. If anything breaks, the build in Nala should fail, which will prevent the automerge.

Interested in hearing some thoughts on this (and whether its a bad idea).

For context, this was my original message to @thypon:

> Hey, I have a question - we have an example project in https://github.com/brave/leo/tree/main/examples/example-ui-react. Its not published/deployed anywhere and is only really used as a test bed during development to see if the React bindings are working properly.
Would it be safe to reduce the frequency of the dependabot/rennovate PRs (or set up automerge in this folder) as there are a lot of them, all the time, and they can cover up the important updates for the main repository.
