### PR TITLE
[Navigation]: Don't show list bullet points

### DIFF
--- a/src/components/navigation/navigationItem.svelte
+++ b/src/components/navigation/navigationItem.svelte
@@ -97,6 +97,8 @@
     --leo-icon-color: var(--leo-color-icon-default);
     --leo-icon-size: var(--leo-icon-s);
 
+    list-style: none;
+
     a,
     button {
       all: unset;


### PR DESCRIPTION
Currently, if you render a `NavigationItem` directly inside a `Navigation`, it will show `•` character which is not really what we want.