### PR TITLE
[Navigation]: Add animations when changing between active nav items

### DIFF
--- a/examples/plain-html/index.html
+++ b/examples/plain-html/index.html
@@ -282,7 +282,7 @@
 
           <leo-navigationitem icon="discover" href="#explore">Explore</leo-navigationitem>
 
-          <leo-navigationitem icon="discover" href="#explore">
+          <leo-navigationitem icon="discover" href="#settings">
             Settings
 
             <leo-navigationmenu slot="subnav">

--- a/examples/plain-html/index.html
+++ b/examples/plain-html/index.html
@@ -108,6 +108,14 @@
     const segmentedControlToggle = segmentedControlExample.querySelector('leo-toggle');
     const segmentedControl = segmentedControlExample.querySelector('leo-segmentedcontrol');
 
+    for (const navItem of document.querySelectorAll('leo-navigationitem')) {
+      navItem.addEventListener('click', e => {
+        const href = navItem.getAttribute('href')
+        if (!href) return
+        window.location = new URL(href, window.location)
+      })
+    }
+
     function updateSelectedOption(e) {
       for (const radio of radios)
         radio.currentValue = e.value

--- a/src/components/navigation/navigation.svelte
+++ b/src/components/navigation/navigation.svelte
@@ -25,8 +25,6 @@
   }
 
   :global(leo-navigation::before), .active-indicator {
-    // Anchor positioned active indicator - we have a fallback in navigationItem
-    // for when this isn't supported.
     @supports (anchor-name: --active-indicator) {
       position-anchor: --active-indicator;
 
@@ -44,6 +42,23 @@
       left: anchor(left);
       top: calc(anchor(top) + var(--anchor-padding));
       bottom: calc(anchor(bottom) + var(--anchor-padding));
+      z-index: 1;
+    }
+  }
+
+  // Fallback active indicator for when the browser doesn't support anchor positioning
+  @supports (not (anchor-name: --active-indicator)) {
+    :global(leo-navigation [data-selected=true]::before), .leo-navigation [data-selected=true]::before {
+      content: '';
+      width: 4px;
+      height: calc(100% - var(--anchor-padding) * 2);
+      border-top-right-radius: var(--leo-radius-xs);
+      border-bottom-right-radius: var(--leo-radius-xs);
+      background: var(--leo-color-text-interactive);
+      position: absolute;
+      left: 0;
+      top: 50%;
+      transform: translateY(-50%);
       z-index: 1;
     }
   }

--- a/src/components/navigation/navigation.svelte
+++ b/src/components/navigation/navigation.svelte
@@ -2,9 +2,7 @@
   export let kind: 'vertical' | 'horizontal' = 'vertical'
 </script>
 
-<div
-  class="leo-navigation kind-{kind}"
->
+<div class="leo-navigation kind-{kind}">
   {#if $$slots.header}
     <slot name="header" />
   {/if}
@@ -16,17 +14,42 @@
   {#if $$slots.actions}
     <slot name="actions" />
   {/if}
+
+  <div class="active-indicator"/>
 </div>
 
 <style lang="scss">
   .leo-navigation {
     --nav-direction: row;
+    --leo-icon-size: var(--leo-icon-s);
+
+    position: relative;
+
     display: flex;
     flex-direction: var(--nav-direction);
     height: 100%;
 
     &.kind-vertical {
       --nav-direction: column;
+    }
+
+    &:has([data-selected="true"]) .active-indicator {
+      --anchor-padding: var(--leo-padding-m);
+
+      position-anchor: --active-indicator;
+
+      transition: top 0.12s ease-in-out, bottom 0.12s ease-in-out, left 0.12s ease-in;
+
+      content: '';
+      width: 4px;
+      border-top-right-radius: var(--leo-radius-xs);
+      border-bottom-right-radius: var(--leo-radius-xs);
+      background: var(--leo-color-text-interactive);
+      position: absolute;
+      left: anchor(left);
+      top: anchor(top);
+      bottom: anchor(bottom);
+      z-index: 1;
     }
   }
 </style>

--- a/src/components/navigation/navigation.svelte
+++ b/src/components/navigation/navigation.svelte
@@ -19,12 +19,38 @@
 </div>
 
 <style lang="scss">
+  :host, .leo-navigation {
+    --anchor-padding: var(--leo-spacing-m);
+    position: relative;
+  }
+
+  :global(leo-navigation::before), .active-indicator {
+    // Anchor positioned active indicator - we have a fallback in navigationItem
+    // for when this isn't supported.
+    @supports (anchor-name: --active-indicator) {
+      position-anchor: --active-indicator;
+
+      transition:
+        top 0.12s ease-in-out,
+        bottom 0.12s ease-in-out,
+        left 0.12s ease-in;
+
+      content: '';
+      width: 4px;
+      border-top-right-radius: var(--leo-radius-xs);
+      border-bottom-right-radius: var(--leo-radius-xs);
+      background: var(--leo-color-text-interactive);
+      position: absolute;
+      left: anchor(left);
+      top: calc(anchor(top) + var(--anchor-padding));
+      bottom: calc(anchor(bottom) + var(--anchor-padding));
+      z-index: 1;
+    }
+  }
+
   .leo-navigation {
     --nav-direction: row;
     --leo-icon-size: var(--leo-icon-s);
-    --anchor-padding: var(--leo-spacing-m);
-
-    position: relative;
 
     display: flex;
     flex-direction: var(--nav-direction);
@@ -32,30 +58,6 @@
 
     &.kind-vertical {
       --nav-direction: column;
-    }
-
-    // Anchor positioned active indicator - we have a fallback in navigationItem
-    // for when this isn't supported.
-    @supports (anchor-name: --active-indicator) {
-      &:has([data-selected='true']) .active-indicator {
-        position-anchor: --active-indicator;
-
-        transition:
-          top 0.12s ease-in-out,
-          bottom 0.12s ease-in-out,
-          left 0.12s ease-in;
-
-        content: '';
-        width: 4px;
-        border-top-right-radius: var(--leo-radius-xs);
-        border-bottom-right-radius: var(--leo-radius-xs);
-        background: var(--leo-color-text-interactive);
-        position: absolute;
-        left: anchor(left);
-        top: calc(anchor(top) + var(--anchor-padding));
-        bottom: calc(anchor(bottom) + var(--anchor-padding));
-        z-index: 1;
-      }
     }
   }
 </style>

--- a/src/components/navigation/navigation.svelte
+++ b/src/components/navigation/navigation.svelte
@@ -15,7 +15,7 @@
     <slot name="actions" />
   {/if}
 
-  <div class="active-indicator"/>
+  <div class="active-indicator" />
 </div>
 
 <style lang="scss">
@@ -33,23 +33,28 @@
       --nav-direction: column;
     }
 
-    &:has([data-selected="true"]) .active-indicator {
-      --anchor-padding: var(--leo-padding-m);
+    @supports (anchor-name: --active-indicator) {
+      &:has([data-selected='true']) .active-indicator {
+        --anchor-padding: var(--leo-spacing-m);
 
-      position-anchor: --active-indicator;
+        position-anchor: --active-indicator;
 
-      transition: top 0.12s ease-in-out, bottom 0.12s ease-in-out, left 0.12s ease-in;
+        transition:
+          top 0.12s ease-in-out,
+          bottom 0.12s ease-in-out,
+          left 0.12s ease-in;
 
-      content: '';
-      width: 4px;
-      border-top-right-radius: var(--leo-radius-xs);
-      border-bottom-right-radius: var(--leo-radius-xs);
-      background: var(--leo-color-text-interactive);
-      position: absolute;
-      left: anchor(left);
-      top: anchor(top);
-      bottom: anchor(bottom);
-      z-index: 1;
+        content: '';
+        width: 4px;
+        border-top-right-radius: var(--leo-radius-xs);
+        border-bottom-right-radius: var(--leo-radius-xs);
+        background: var(--leo-color-text-interactive);
+        position: absolute;
+        left: anchor(left);
+        top: calc(anchor(top) + var(--anchor-padding));
+        bottom: calc(anchor(bottom) + var(--anchor-padding));
+        z-index: 1;
+      }
     }
   }
 </style>

--- a/src/components/navigation/navigation.svelte
+++ b/src/components/navigation/navigation.svelte
@@ -22,6 +22,7 @@
   .leo-navigation {
     --nav-direction: row;
     --leo-icon-size: var(--leo-icon-s);
+    --anchor-padding: var(--leo-spacing-m);
 
     position: relative;
 
@@ -33,10 +34,10 @@
       --nav-direction: column;
     }
 
+    // Anchor positioned active indicator - we have a fallback in navigationItem
+    // for when this isn't supported.
     @supports (anchor-name: --active-indicator) {
       &:has([data-selected='true']) .active-indicator {
-        --anchor-padding: var(--leo-spacing-m);
-
         position-anchor: --active-indicator;
 
         transition:

--- a/src/components/navigation/navigationItem.svelte
+++ b/src/components/navigation/navigationItem.svelte
@@ -52,7 +52,8 @@
   export let onClick: () => void = undefined
 
   const checkIfCurrent = () => {
-    isCurrent = window.location.pathname === href || window.location.hash === href;
+    isCurrent =
+      window.location.pathname === href || window.location.hash === href
   }
 
   $: tag = href ? 'a' : ('button' as 'a' | 'button')
@@ -71,14 +72,17 @@
 <svelte:window on:popstate={checkIfCurrent} on:hashchange={checkIfCurrent} />
 
 <!-- Note that this doesn't currently work properly in WC land due to the nested dynamic elements -->
-<svelte:element this={outsideList ? 'div' : 'li'} class="leo-navigation-item">
+<svelte:element
+  this={outsideList ? 'div' : 'li'}
+  class="leo-navigation-item"
+  data-selected={isCurrent}
+>
   <svelte:element
     this={tag}
     href={href || undefined}
     disabled={isLoading || isDisabled || undefined}
     on:click={onClick}
     {...$$restProps}
-    class:isCurrent
   >
     {#if icon}
       <Icon name={icon} />
@@ -92,10 +96,28 @@
 </svelte:element>
 
 <style lang="scss">
+  :host {
+    position: relative;
+  }
+
   .leo-navigation-item {
     --nav-item-color: var(--leo-color-text-secondary);
     --leo-icon-color: var(--leo-color-icon-default);
-    --leo-icon-size: var(--leo-icon-s);
+
+    position: relative;
+
+    // When this item is selected, set it as the active indicator
+    &[data-selected='true'] {
+    --nav-item-color: var(--leo-color-text-interactive);
+    --leo-icon-color: var(--leo-color-icon-interactive);
+      anchor-name: --active-indicator;
+    }
+
+    // If a parent is selected, change the nav item color to unselected
+    [data-selected='true'] & {
+      --nav-item-color: var(--leo-color-text-secondary);
+      --leo-icon-color: var(--leo-color-icon-default);
+    }
 
     a,
     button {
@@ -111,7 +133,6 @@
       padding-right: var(--leo-spacing-m);
       border-radius: 0;
       outline: none;
-      position: relative;
       text-decoration: none;
 
       font: var(--leo-font-components-navbutton);
@@ -123,24 +144,6 @@
 
       &:focus-visible {
         box-shadow: var(--leo-effect-focus-state);
-      }
-
-      &.isCurrent {
-        --nav-item-color: var(--leo-color-text-interactive);
-        --leo-icon-color: var(--leo-color-icon-interactive);
-
-        &::before {
-          content: '';
-          width: 4px;
-          height: 76%;
-          border-top-right-radius: var(--leo-radius-xs);
-          border-bottom-right-radius: var(--leo-radius-xs);
-          background: var(--leo-color-text-interactive);
-          position: absolute;
-          left: 0;
-          top: 50%;
-          transform: translateY(-50%);
-        }
       }
     }
   }

--- a/src/components/navigation/navigationItem.svelte
+++ b/src/components/navigation/navigationItem.svelte
@@ -116,6 +116,10 @@
     anchor-name: --active-indicator;
   }
 
+  :host {
+    position: relative;
+  }
+
   .leo-navigation-item {
     --nav-item-color: var(--leo-color-text-secondary);
     --leo-icon-color: var(--leo-color-icon-default);
@@ -126,22 +130,6 @@
     &[data-selected='true'] {
       --nav-item-color: var(--leo-color-text-interactive);
       --leo-icon-color: var(--leo-color-icon-interactive);
-
-      // Fallback active indicator for when the browser doesn't support anchor positioning
-      @supports (not (anchor-name: --active-indicator)) {
-        &::before {
-          content: '';
-          width: 4px;
-          height: calc(100% - var(--anchor-padding) * 2);
-          border-top-right-radius: var(--leo-radius-xs);
-          border-bottom-right-radius: var(--leo-radius-xs);
-          background: var(--leo-color-text-interactive);
-          position: absolute;
-          left: 0;
-          top: 50%;
-          transform: translateY(-50%);
-        }
-      }
     }
 
     // If a parent is selected, change the nav item color to unselected

--- a/src/components/navigation/navigationItem.svelte
+++ b/src/components/navigation/navigationItem.svelte
@@ -108,9 +108,25 @@
 
     // When this item is selected, set it as the active indicator
     &[data-selected='true'] {
-    --nav-item-color: var(--leo-color-text-interactive);
-    --leo-icon-color: var(--leo-color-icon-interactive);
+      --nav-item-color: var(--leo-color-text-interactive);
+      --leo-icon-color: var(--leo-color-icon-interactive);
       anchor-name: --active-indicator;
+
+      // Fallback active indicator for when the browser doesn't support anchor positioning
+      @supports (not (anchor-name: --active-indicator)) {
+        &::before {
+          content: '';
+          width: 4px;
+          height: calc(100% - var(--anchor-padding) * 2);
+          border-top-right-radius: var(--leo-radius-xs);
+          border-bottom-right-radius: var(--leo-radius-xs);
+          background: var(--leo-color-text-interactive);
+          position: absolute;
+          left: 0;
+          top: 50%;
+          transform: translateY(-50%);
+        }
+      }
     }
 
     // If a parent is selected, change the nav item color to unselected


### PR DESCRIPTION
I've used `anchor-positioning` for the animations, so they work without any JS. Because its a fairly new API I've left in a fallback with no animations.