### PR TITLE
[WebComponents]: Ignore pure whitespace nodes

### DIFF
--- a/src/components/svelte-web.ts
+++ b/src/components/svelte-web.ts
@@ -134,8 +134,11 @@ export default function registerWebComponent(
       const slotsNames = Array.from(this.children).map((c) =>
         c.getAttribute('slot')
       )
-      // Add default slot if there are nodes without a slot name.
-      if (this.childNodes.length > slotsNames.length) slotsNames.push(null)
+      // Add default slot if there are non-empty nodes without a slot name.
+      const nonEmptyNodes = Array.from(this.childNodes).filter(
+        (c) => c.nodeName !== '#text' || c.textContent.trim().length
+      )
+      if (nonEmptyNodes.length > slotsNames.length) slotsNames.push(null)
 
       const distinctSlots = new Set(this.#lastSlots)
       // Slots didn't change, so nothing to do here.


### PR DESCRIPTION
@szilardszaloki has been migrating some components to LitElement and noticed that the `leo-icon` elements weren't working.

Our working theory is that `Lit` injects whitespace into its HTML elements (there's a slotted `\n`):
https://search.brave.com/search?q=litelement+adds+whitespace+to+webcomponents&source=desktop&summary=1&summary_og=f0f84d159a7ddd8a5ff175