### PR TITLE
[Automerge]: Remove CODEOWNERs for package.json

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,5 @@
 * @fallaciousreasoning @petemill @alanbreck
+
+# We don't specify a CODEOWNER for these files, so automerge works for dependabot
+package.json
+package-lock.json


### PR DESCRIPTION
At the moment, apps (such as `rennovate-approve[bot]`) can't be specified as CODEOWNERs, which means automerge doesn't work, because the PR is only approved by a bot.

https://github.com/orgs/community/discussions/23064#discussioncomment-3238917

Talked to @thypon and we're going to try the solution from the above discussion (removing CODEOWNERs requirement for package.json and package-lock.json).