### PR TITLE
**Breaking** [Alert] Introduce notice type, remove mode prop, and title slot will always show if it has content

### DIFF
--- a/src/components/alert/alert.stories.svelte
+++ b/src/components/alert/alert.stories.svelte
@@ -72,8 +72,8 @@
       This can be used to override the default icon for the different types of
       Alert"
     >
-      <Alert {...args} mode="full">
-        <div slot="title">Title</div>
+      <Alert {...args} mode="full" hasTitle={!!args.title.length}>
+        <div slot="title">{args.title}</div>
         Some content
       </Alert>
     </Slot>
@@ -103,6 +103,7 @@
     types: { table: { disable: true } },
     type: { control: 'select', options: types },
     hasActions: { control: 'boolean' },
+    title: { type: 'string', defaultValue: 'Title' },
     '--leo-alert-center-width': {
       type: 'string',
       description: 'The width to apply to the alert center'
@@ -116,11 +117,14 @@
       description: 'The css padding for the alert'
     }
   }}
+  args={{
+    title: 'Arg Title',
+  }}
 />
 
 <Template let:args>
-  <Alert {...args}>
-    <div slot="title">Title</div>
+  <Alert {...args} hasTitle={!!args.title.length}>
+    <div slot="title">{args.title}</div>
     Alert content
     <div slot="actions" class:reverse={args.mode === 'full'}>
       <Button kind="plain-faint">Secondary</Button>
@@ -134,8 +138,8 @@
   <div class="container">
     {#each modes as mode}
       {#each types as type}
-        <Alert {mode} {type} {...args}>
-          <div slot="title">Title</div>
+        <Alert {mode} {type} {...args} hasTitle={mode === 'full' && !!args.title.length}>
+          <div slot="title">{args.title}</div>
           Alert content
           <div slot="actions" class="actions" class:reverse={mode === 'full'}>
             <Button kind="plain-faint">Secondary</Button>

--- a/src/components/alert/alert.stories.svelte
+++ b/src/components/alert/alert.stories.svelte
@@ -2,7 +2,7 @@
   import { Meta, Story, Template } from '@storybook/addon-svelte-csf'
   import Button from '../button/button.svelte'
 
-  import Alert, { modes, types } from './alert.svelte'
+  import Alert, { types } from './alert.svelte'
   import { showAlert } from './alertCenter.svelte'
   import Icon from '../icon/icon.svelte'
   import Slot from '../../storyHelpers/Slot.svelte'
@@ -16,12 +16,11 @@
   let duration = 2000
   let customButton = false
 
-  $: alertUser = (mode, type) =>
+  $: alertUser = (type) =>
     showAlert(
       {
         content,
         title,
-        mode: mode ?? 'simple',
         type: type ?? 'error',
         actions: hasAction
           ? [
@@ -59,7 +58,7 @@
       name="content-after"
       explanation="optional content after the main content of the alert"
     >
-      <Alert {...args} mode="simple">
+      <Alert {...args}>
         Some content
         <Button kind="plain-faint" fab slot="content-after">
           <Icon name="close" />
@@ -72,7 +71,7 @@
       This can be used to override the default icon for the different types of
       Alert"
     >
-      <Alert {...args} mode="full" hasTitle={!!args.title.length}>
+      <Alert {...args}>
         <div slot="title">{args.title}</div>
         Some content
       </Alert>
@@ -98,8 +97,6 @@
   title="Components/Alert"
   component={Alert}
   argTypes={{
-    modes: { table: { disable: true } },
-    mode: { control: 'select', options: modes },
     types: { table: { disable: true } },
     type: { control: 'select', options: types },
     hasActions: { control: 'boolean' },
@@ -118,15 +115,15 @@
     }
   }}
   args={{
-    title: 'Arg Title',
+    title: 'Alert title',
   }}
 />
 
 <Template let:args>
-  <Alert {...args} hasTitle={!!args.title.length}>
+  <Alert {...args}>
     <div slot="title">{args.title}</div>
     Alert content
-    <div slot="actions" class:reverse={args.mode === 'full'}>
+    <div slot="actions">
       <Button kind="plain-faint">Secondary</Button>
       <Button kind="filled">Primary</Button>
     </div>
@@ -136,14 +133,14 @@
 <Story name="Alert" />
 <Story name="All" let:args>
   <div class="container">
-    {#each modes as mode}
+    {#each [true, false] as hasTitle}
       {#each types as type}
-        <Alert {mode} {type} {...args} hasTitle={mode === 'full' && !!args.title.length}>
-          <div slot="title">{args.title}</div>
+        <Alert {type} {...args}>
+          <div slot="title">{#if hasTitle}{args.title}{/if}</div>
           Alert content
-          <div slot="actions" class="actions" class:reverse={mode === 'full'}>
-            <Button kind="plain-faint">Secondary</Button>
+          <div slot="actions" class="actions">
             <Button kind="filled">Primary</Button>
+            <Button kind="plain-faint">Secondary</Button>
           </div>
         </Alert>
       {/each}
@@ -182,7 +179,7 @@
   </div>
   <Button
     onClick={() => {
-      alertUser(args.mode, args.type)
+      alertUser(args.type)
     }}>Show Alert</Button
   >
 </Story>

--- a/src/components/alert/alert.svelte
+++ b/src/components/alert/alert.svelte
@@ -4,9 +4,6 @@
   export const types = ['info', 'warning', 'error', 'success', 'notice'] as const
   export type AlertType = (typeof types)[number]
 
-  export const modes = ['simple', 'full'] as const
-  export type AlertMode = (typeof modes)[number]
-
   const defaultIcons: { [P in AlertType]: IconName } = {
     'info': 'info-filled',
     'error': 'warning-circle-filled',
@@ -20,22 +17,19 @@
   import Icon from '../icon/icon.svelte'
 
   export let type: AlertType = 'error'
-  export let mode: AlertMode = 'simple'
   export let isToast = false
-  export let hasActions = $$slots.actions
-  export let hasContentAfter = $$slots['content-after']
-  export let hasTitle = $$slots.title
   export let hideIcon = false
 
+  // TODO: Remove when only supporting svelte >5 which can render slotted content conditionally
+  export let hasActions = $$slots.actions
+  export let hasContentAfter = $$slots['content-after']
+
   $: currentType = type ?? 'error'
-  $: currentMode = hasTitle ? 'full' : mode ?? 'simple'
 </script>
 
 <div
   class="leo-alert {currentType}"
   class:toast={isToast}
-  class:simple={currentMode === 'simple'}
-  class:full={currentMode === 'full'}
 >
   {#if !hideIcon}
   <div class="icon">
@@ -45,7 +39,7 @@
   </div>
   {/if}
   <div class="content">
-    {#if hasTitle && $$slots.title}
+    {#if $$slots.title}
       <div class="title">
         <slot name="title" />
       </div>
@@ -87,7 +81,7 @@
     border: var(--leo-alert-border-width, var(--default-border-width)) solid
       var(--leo-alert-border-color, var(--default-border-color));
     gap: var(--leo-spacing-xl) 0;
-    font: var(--default-font, var(--leo-font-default-regular));
+    font: var(--leo-font-default-regular);
 
     display: grid;
     grid-template-columns: min-content 1fr;
@@ -98,8 +92,6 @@
       --default-text-color: var(--leo-alert-text-color, var(--leo-color-text-tertiary));
       --default-border-width: 1px;
       --default-border-color: var(--leo-color-divider-subtle);
-      --default-title-font: var(--leo-font-default-semibold);
-      --default-font: var(--leo-font-small-regular);
     }
     &.success {
       --default-background: var(--leo-color-systemfeedback-success-background);
@@ -132,13 +124,9 @@
       color: var(--leo-icon-color);
       margin-right: var(--leo-spacing-xl);
     }
-    &.notice .icon {
-      --leo-icon-size: var(--leo-icon-s);
-      margin-right: var(--leo-spacing-l);
-    }
 
     & .title {
-      font: var(--default-title-font, var(--leo-font-heading-h4));
+      font: var(--leo-font-heading-h4);
     }
 
     & .content {
@@ -172,12 +160,5 @@
     &.success {
       background: var(--leo-color-green-20);
     }
-  }
-
-  .leo-alert.full .icon {
-    --leo-icon-size: var(--leo-icon-xl);
-  }
-  .leo-alert.notice.full .icon {
-    --leo-icon-size: var(--leo-icon-l);
   }
 </style>

--- a/src/components/alert/alert.svelte
+++ b/src/components/alert/alert.svelte
@@ -21,10 +21,11 @@
   export let isToast = false
   export let hasActions = $$slots.actions
   export let hasContentAfter = $$slots['content-after']
+  export let hasTitle = $$slots.title
   export let hideIcon = false
 
   $: currentType = type ?? 'error'
-  $: currentMode = mode ?? 'simple'
+  $: currentMode = hasTitle ? 'full' : mode ?? 'simple'
 </script>
 
 <div
@@ -44,7 +45,7 @@
   </div>
   {/if}
   <div class="content">
-    {#if mode === 'full' && $$slots.title}
+    {#if hasTitle && $$slots.title}
       <div class="title">
         <slot name="title" />
       </div>

--- a/src/components/alert/alert.svelte
+++ b/src/components/alert/alert.svelte
@@ -1,15 +1,18 @@
 <script lang="ts" context="module">
-  export const types = ['info', 'warning', 'error', 'success'] as const
+  import type { IconName } from '@brave/leo/icons/meta'
+
+  export const types = ['info', 'warning', 'error', 'success', 'notice'] as const
   export type AlertType = (typeof types)[number]
 
   export const modes = ['simple', 'full'] as const
   export type AlertMode = (typeof modes)[number]
 
-  const defaultIcons: { [P in AlertType]: string } = {
+  const defaultIcons: { [P in AlertType]: IconName } = {
     'info': 'info-filled',
     'error': 'warning-circle-filled',
     'warning': 'warning-triangle-filled',
-    'success': 'check-circle-filled'
+    'success': 'check-circle-filled',
+    'notice': 'info-outline'
   }
 </script>
 
@@ -33,9 +36,6 @@
   class:toast={isToast}
   class:simple={currentMode === 'simple'}
   class:full={currentMode === 'full'}
-  style:--default-background={`var(--leo-color-systemfeedback-${currentType}-background)`}
-  style:--default-icon-color={`var(--leo-color-systemfeedback-${currentType}-icon)`}
-  style:--default-text-color={`var(--leo-color-systemfeedback-${currentType}-text)`}
 >
   {#if !hideIcon}
   <div class="icon">
@@ -84,11 +84,43 @@
     color: var(--default-text-color, var(--leo-color-text-primary));
     padding: var(--leo-alert-padding, var(--leo-spacing-xl));
     border-radius: var(--leo-radius-m);
+    border: var(--leo-alert-border-width, var(--default-border-width)) solid
+      var(--leo-alert-border-color, var(--default-border-color));
     gap: var(--leo-spacing-xl) 0;
-    font: var(--leo-font-default-regular);
+    font: var(--default-font, var(--leo-font-default-regular));
 
     display: grid;
     grid-template-columns: min-content 1fr;
+
+    &.notice {
+      --default-background: transparent;
+      --default-icon-color: var(--leo-color-text-tertiary);
+      --default-text-color: var(--leo-alert-text-color, var(--leo-color-text-tertiary));
+      --default-border-width: 1px;
+      --default-border-color: var(--leo-color-divider-subtle);
+      --default-title-font: var(--leo-font-default-semibold);
+      --default-font: var(--leo-font-small-regular);
+    }
+    &.success {
+      --default-background: var(--leo-color-systemfeedback-success-background);
+      --default-icon-color: var(--leo-color-systemfeedback-success-icon);
+      --default-text-color: var(--leo-color-systemfeedback-success-text);
+    }
+    &.info {
+      --default-background: var(--leo-color-systemfeedback-info-background);
+      --default-icon-color: var(--leo-color-systemfeedback-info-icon);
+      --default-text-color: var(--leo-color-systemfeedback-info-text);
+    }
+    &.error {
+      --default-background: var(--leo-color-systemfeedback-error-background);
+      --default-icon-color: var(--leo-color-systemfeedback-error-icon);
+      --default-text-color: var(--leo-color-systemfeedback-error-text);
+    }
+    &.warning {
+      --default-background: var(--leo-color-systemfeedback-warning-background);
+      --default-icon-color: var(--leo-color-systemfeedback-warning-icon);
+      --default-text-color: var(--leo-color-systemfeedback-warning-text);
+    }
 
     &:has(.content-after) {
       grid-template-columns: min-content 1fr auto;
@@ -100,9 +132,13 @@
       color: var(--leo-icon-color);
       margin-right: var(--leo-spacing-xl);
     }
+    &.notice .icon {
+      --leo-icon-size: var(--leo-icon-s);
+      margin-right: var(--leo-spacing-l);
+    }
 
     & .title {
-      font: var(--leo-font-heading-h4);
+      font: var(--default-title-font, var(--leo-font-heading-h4));
     }
 
     & .content {
@@ -140,5 +176,8 @@
 
   .leo-alert.full .icon {
     --leo-icon-size: var(--leo-icon-xl);
+  }
+  .leo-alert.notice.full .icon {
+    --leo-icon-size: var(--leo-icon-l);
   }
 </style>

--- a/src/components/alert/alertCenter.svelte
+++ b/src/components/alert/alertCenter.svelte
@@ -1,5 +1,5 @@
 <script lang="ts" context="module">
-  import type { AlertMode, AlertType } from './alert.svelte'
+  import type { AlertType } from './alert.svelte'
   import { writable } from 'svelte/store'
 
   /**
@@ -24,7 +24,6 @@
   })
 
   export interface AlertOptions {
-    mode: AlertMode
     type: AlertType
     content: string
     title?: string
@@ -37,7 +36,6 @@
   class AlertInfo {
     id = ++nextId
 
-    mode: AlertMode
     type: AlertType
     content: string
     title?: string
@@ -130,7 +128,7 @@
           {#each alert.actions as action}
             <svelte:component
               this={action.component || ButtonComponent}
-              size={alert.mode === "full" ? "medium" : "small"}
+              size="small"
               fab={action.icon && !action.text}
               kind={action.kind || 'filled'}
               onClick={() => action.action(alert)}


### PR DESCRIPTION
If a title slot was provided and the mode wasn't set to full then the title would never show. Seems to me that the full mode is only for adjustments made to make the alert look good with a title - ~so this PR forces 'full' mode when a title is present (or hasTitle prop is true for when the framework can't have an optional slot!)~. After discussion with @aguscruiz this PR removes `mode="full"` (leaving only a single mode, and removing it) as it wasn't being used by any designs, and allows title without any mode restriction

This also adds a variant for 'notice' type, which is color-less and has smaller features.

<img width="527" alt="image" src="https://github.com/user-attachments/assets/52cac46d-e59c-4ddc-8740-ba6deb67783b">
<img width="524" alt="image" src="https://github.com/user-attachments/assets/8c0b885f-b485-4875-8a11-d0a271e62566">

