### PR TITLE
Update label style to match figma

### DIFF
--- a/src/components/label/label.svelte
+++ b/src/components/label/label.svelte
@@ -23,16 +23,16 @@
 
   $: background =
     mode === 'default'
-      ? `var(--leo-color-${color}-20)`
+      ? `var(--leo-color-${color}-10)`
       : mode === 'loud'
-        ? `var(--leo-color-${color}-50)`
+        ? `var(--leo-color-${color}-40)`
         : 'transparent'
 
   $: text =
     mode === 'default'
-      ? `var(--leo-color-${color}-50)`
+      ? `var(--leo-color-${color}-60)`
       : mode === 'loud'
-        ? `var(--leo-color-${color}-10)`
+        ? `var(--leo-color-white)`
         : `var(--leo-color-${color}-50)`
 
   $: border = mode === 'outline' ? `var(--leo-color-${color}-50)` : `transparent`


### PR DESCRIPTION
Resolves https://github.com/brave/leo/issues/574

Update label styles to match Figma's latest version.
https://www.figma.com/design/g8Z0q6TMPYDq6zXh9Y7LWD/%F0%9F%8C%8E-Universal?m=auto&node-id=195-15172&t=YtEkhqaM1E4QR5ZC-1

![image](https://github.com/user-attachments/assets/43fa1535-1705-49bd-a139-56407de2ca42)
