### PR TITLE
Avoid deprecated meta-tag pattern

### DIFF
--- a/src/components/alert/alert.stories.svelte
+++ b/src/components/alert/alert.stories.svelte
@@ -1,8 +1,37 @@
+<script context="module">
+  import Alert, { types } from './alert.svelte'
+
+  export const meta = {
+    title: "Components/Alert",
+    component: Alert,
+    argTypes: {
+      types: { table: { disable: true } },
+      type: { control: 'select', options: types },
+      hasActions: { control: 'boolean' },
+      title: { type: 'string', defaultValue: 'Title' },
+      '--leo-alert-center-width': {
+        type: 'string',
+        description: 'The width to apply to the alert center'
+      },
+      '--leo-alert-center-position': {
+        type: 'string',
+        description: 'The position of the alert center'
+      },
+      '--leo-alert-padding': {
+        type: 'string',
+        description: 'The css padding for the alert'
+      }
+    },
+    args: {
+      title: 'Alert title'
+    }
+  }
+
+</script>
 <script lang="ts">
-  import { Meta, Story, Template } from '@storybook/addon-svelte-csf'
+  import { Story, Template } from '@storybook/addon-svelte-csf'
   import Button from '../button/button.svelte'
 
-  import Alert, { types } from './alert.svelte'
   import { showAlert } from './alertCenter.svelte'
   import Icon from '../icon/icon.svelte'
   import Slot from '../../storyHelpers/Slot.svelte'
@@ -93,32 +122,6 @@
   </SlotInfo>
 </Story>
 
-<Meta
-  title="Components/Alert"
-  component={Alert}
-  argTypes={{
-    types: { table: { disable: true } },
-    type: { control: 'select', options: types },
-    hasActions: { control: 'boolean' },
-    title: { type: 'string', defaultValue: 'Title' },
-    '--leo-alert-center-width': {
-      type: 'string',
-      description: 'The width to apply to the alert center'
-    },
-    '--leo-alert-center-position': {
-      type: 'string',
-      description: 'The position of the alert center'
-    },
-    '--leo-alert-padding': {
-      type: 'string',
-      description: 'The css padding for the alert'
-    }
-  }}
-  args={{
-    title: 'Alert title',
-  }}
-/>
-
 <Template let:args>
   <Alert {...args}>
     <div slot="title">{args.title}</div>
@@ -130,7 +133,7 @@
   </Alert>
 </Template>
 
-<Story name="Alert" />
+<Story name="Default Alert" />
 <Story name="All" let:args>
   <div class="container">
     {#each [true, false] as hasTitle}

--- a/src/components/button/button.stories.svelte
+++ b/src/components/button/button.stories.svelte
@@ -1,8 +1,33 @@
-<script lang="ts">
-  import { Meta, Story, Template } from '@storybook/addon-svelte-csf'
-
+<script context="module">
   import Button from './button.svelte'
   import { buttonKinds, buttonSizes } from './props'
+
+  export const meta = {
+    title: "Components/Button",
+    component: Button,
+    argTypes: {
+      '--leo-button-color': {
+        control: 'color'
+      },
+      '--leo-button-padding': {
+        control: 'text',
+        type: 'string',
+        description: 'The padding to apply to the button content'
+      },
+      '--leo-button-radius': {
+        control: 'text',
+        type: 'string',
+        description: 'The border-radius of the button'
+      },
+      kind: { control: 'select', options: buttonKinds },
+      size: { control: 'select', options: buttonSizes },
+      isDisabled: { control: 'boolean' }
+    }
+  }
+</script>
+<script lang="ts">
+  import { Story, Template } from '@storybook/addon-svelte-csf'
+
   import SlotInfo from '../../storyHelpers/SlotInfo.svelte'
   import Slot from '../../storyHelpers/Slot.svelte'
   import Icon from '../icon/icon.svelte'
@@ -12,29 +37,6 @@
     count += 1
   }
 </script>
-
-<Meta
-  title="Components/Button"
-  component={Button}
-  argTypes={{
-    '--leo-button-color': {
-      control: 'color'
-    },
-    '--leo-button-padding': {
-      control: 'text',
-      type: 'string',
-      description: 'The padding to apply to the button content'
-    },
-    '--leo-button-radius': {
-      control: 'text',
-      type: 'string',
-      description: 'The border-radius of the button'
-    },
-    kind: { control: 'select', options: buttonKinds },
-    size: { control: 'select', options: buttonSizes },
-    isDisabled: { control: 'boolean' }
-  }}
-/>
 
 <Template let:args>
   <Button {...args} onClick={handleClick}>

--- a/src/components/buttonMenu/buttonMenu.stories.svelte
+++ b/src/components/buttonMenu/buttonMenu.stories.svelte
@@ -1,7 +1,22 @@
-<script lang="ts">
-  import { Meta, Story, Template } from '@storybook/addon-svelte-csf'
-
+<script context="module">
   import ButtonMenu from './buttonMenu.svelte'
+
+  export const meta = {
+    title: 'Components/ButtonMenu',
+    component: ButtonMenu,
+    argTypes: {
+      '--leo-menu-control-width': {
+        description: '(readonly): Computed width of menu control'
+      },
+      '--leo-menu-max-height': {
+        description: 'user controlled max height'
+      }
+    }
+  }
+</script>
+<script lang="ts">
+  import { Story, Template } from '@storybook/addon-svelte-csf'
+
   import Icon from '../icon/icon.svelte'
   import SlotInfo from '../../storyHelpers/SlotInfo.svelte'
   import Slot from '../../storyHelpers/Slot.svelte'
@@ -13,19 +28,6 @@
 
   const handleAction = () => console.log('action')
 </script>
-
-<Meta
-  title="Components/ButtonMenu"
-  component={ButtonMenu}
-  argTypes={{
-    '--leo-menu-control-width': {
-      description: '(readonly): Computed width of menu control'
-    },
-    '--leo-menu-max-height': {
-      description: 'user controlled max height'
-    }
-  }}
-/>
 
 <Template let:args>
   <div class="container">

--- a/src/components/checkbox/checkbox.stories.svelte
+++ b/src/components/checkbox/checkbox.stories.svelte
@@ -1,79 +1,82 @@
-<script>
-  import { Meta, Story, Template } from '@storybook/addon-svelte-csf'
+<script context="module">
   import Checkbox, { sizes } from './checkbox.svelte'
+
+  export const meta = {
+    title: 'Components/Checkbox',
+    component: Checkbox,
+    argTypes: {
+      '--leo-checkbox-focus-border-radius': {
+        control: 'text',
+        type: 'string',
+        description: 'The border radius of the focus shadow'
+      },
+      '--leo-checkbox-label-gap': {
+        control: 'text',
+        type: 'string',
+        description: 'The gap between the label and the checkbox'
+      },
+      '--leo-checkbox-flex-direction': {
+        control: 'select',
+        description: 'The flex direction of the label/checkbox',
+        options: ['row', 'row-reverse', 'column', 'column-reverse']
+      },
+      '--leo-checkbox-checked-color': {
+        control: 'color',
+        type: 'string',
+        description: 'The color of the checkbox when checked'
+      },
+      '--leo-checkbox-checked-color-hover': {
+        control: 'color',
+        type: 'string',
+        description: 'The color of the checkbox when checked and hovered'
+      },
+      '--leo-checkbox-unchecked-color': {
+        control: 'color',
+        type: 'string',
+        description: 'The color of the checkbox when unchecked'
+      },
+      '--leo-checkbox-unchecked-color-hover': {
+        control: 'color',
+        type: 'string',
+        description: 'The color of the checkbox when unchecked and hovered'
+      },
+      '--leo-checkbox-font': {
+        control: 'text',
+        type: 'string',
+        description: 'The font to use for the label'
+      },
+      '--disabled-color': {
+        control: 'color',
+        type: 'string',
+        description: 'The color of the checkbox + label when disabled'
+      },
+      size: {
+        control: 'select',
+        description: 'The size of the checkbox',
+        options: sizes
+      },
+      checked: {
+        control: 'boolean',
+        description: 'Is the checkbox checked'
+      },
+      label: {
+        control: 'text',
+        description: 'The checkbox label. This is passed in via slot'
+      }
+    },
+    args: {
+      label: 'Label',
+      checked: false,
+      size: 'normal'
+    }
+  }
+</script>
+
+<script>
+  import { Story, Template } from '@storybook/addon-svelte-csf'
   import Slot from '../../storyHelpers/Slot.svelte'
   import SlotInfo from '../../storyHelpers/SlotInfo.svelte'
 </script>
-
-<Meta
-  title="Components/Checkbox"
-  component={Checkbox}
-  argTypes={{
-    '--leo-checkbox-focus-border-radius': {
-      control: 'text',
-      type: 'string',
-      description: 'The border radius of the focus shadow'
-    },
-    '--leo-checkbox-label-gap': {
-      control: 'text',
-      type: 'string',
-      description: 'The gap between the label and the checkbox'
-    },
-    '--leo-checkbox-flex-direction': {
-      control: 'select',
-      description: 'The flex direction of the label/checkbox',
-      options: ['row', 'row-reverse', 'column', 'column-reverse']
-    },
-    '--leo-checkbox-checked-color': {
-      control: 'color',
-      type: 'string',
-      description: 'The color of the checkbox when checked'
-    },
-    '--leo-checkbox-checked-color-hover': {
-      control: 'color',
-      type: 'string',
-      description: 'The color of the checkbox when checked and hovered'
-    },
-    '--leo-checkbox-unchecked-color': {
-      control: 'color',
-      type: 'string',
-      description: 'The color of the checkbox when unchecked'
-    },
-    '--leo-checkbox-unchecked-color-hover': {
-      control: 'color',
-      type: 'string',
-      description: 'The color of the checkbox when unchecked and hovered'
-    },
-    '--leo-checkbox-font': {
-      control: 'text',
-      type: 'string',
-      description: 'The font to use for the label'
-    },
-    '--disabled-color': {
-      control: 'color',
-      type: 'string',
-      description: 'The color of the checkbox + label when disabled'
-    },
-    size: {
-      control: 'select',
-      description: 'The size of the checkbox',
-      options: sizes
-    },
-    checked: {
-      control: 'boolean',
-      description: 'Is the checkbox checked'
-    },
-    label: {
-      control: 'text',
-      description: 'The checkbox label. This is passed in via slot'
-    }
-  }}
-  args={{
-    label: 'Label',
-    checked: false,
-    size: 'normal'
-  }}
-/>
 
 <Template let:args>
   <Checkbox {...args}>{args.label}</Checkbox>

--- a/src/components/collapse/collapse.stories.svelte
+++ b/src/components/collapse/collapse.stories.svelte
@@ -1,82 +1,85 @@
+<script context="module">
+  import Collapse from './collapse.svelte'
+
+  export const meta = {
+    title: 'Components/Collapse',
+    component: Collapse,
+    argTypes: {
+      '--leo-collapse-summary-padding': {
+        type: 'string',
+        description: 'The padding to apply to the collapse summary'
+      },
+      '--leo-collapse-content-padding': {
+        type: 'string',
+        description: 'The padding to apply to the collapse content'
+      },
+      '--leo-collapse-background-color': {
+        control: 'color',
+        description: 'The background color of the collapse'
+      },
+      '--leo-collapse-background-color-hover': {
+        control: 'color',
+        description: 'The background color of the collapse when hovering'
+      },
+      '--leo-collapse-icon-size': {
+        type: 'string',
+        description: 'The size of icons in the collapse'
+      },
+      '--leo-collapse-transition-duration': {
+        type: 'string',
+        description: 'The transition duration'
+      },
+      '--leo-collapse-border-color': {
+        control: 'color',
+        description: 'The border color of the collapse'
+      },
+      '--leo-collapse-border-color-hover': {
+        control: 'color',
+        description: 'The border color of the collapse when hovered'
+      },
+      '--leo-collapse-shadow': {
+        type: 'string',
+        description: 'The shadow of the collapse'
+      },
+      '--leo-collapse-shadow-hover': {
+        type: 'string',
+        description: 'The shadow of the collapse when hovered'
+      },
+      '--leo-collapse-shadow-focus': {
+        type: 'string',
+        description: 'The shadow of the collapse when focused'
+      },
+      '--leo-collapse-radius': {
+        type: 'string',
+        description: 'The border radius of the collapse'
+      },
+      '--leo-collapse-summary-color': {
+        control: 'color',
+        description: 'The color of the summary text'
+      },
+      '--leo-collapse-summary-color-hover': {
+        control: 'color',
+        description: 'The color of the summary text when hovered'
+      },
+      '--leo-collapse-icon-color': {
+        control: 'color',
+        description: 'The color of the icons in the collapse'
+      },
+      '--leo-collapse-icon-color-hover': {
+        control: 'color',
+        description: 'The color of icons in the collapse in a hover state'
+      }
+    }
+  }
+</script>
+
 <script>
-  import { Meta, Story, Template } from '@storybook/addon-svelte-csf'
+  import { Story, Template } from '@storybook/addon-svelte-csf'
   import Icon from '../icon/icon.svelte'
 
-  import Collapse from './collapse.svelte'
   import SlotInfo from '../../storyHelpers/SlotInfo.svelte'
   import Slot from '../../storyHelpers/Slot.svelte'
 </script>
-
-<Meta
-  title="Components/Collapse"
-  component={Collapse}
-  argTypes={{
-    '--leo-collapse-summary-padding': {
-      type: 'string',
-      description: 'The padding to apply to the collapse summary'
-    },
-    '--leo-collapse-content-padding': {
-      type: 'string',
-      description: 'The padding to apply to the collapse content'
-    },
-    '--leo-collapse-background-color': {
-      control: 'color',
-      description: 'The background color of the collapse'
-    },
-    '--leo-collapse-background-color-hover': {
-      control: 'color',
-      description: 'The background color of the collapse when hovering'
-    },
-    '--leo-collapse-icon-size': {
-      type: 'string',
-      description: 'The size of icons in the collapse'
-    },
-    '--leo-collapse-transition-duration': {
-      type: 'string',
-      description: 'The transition duration'
-    },
-    '--leo-collapse-border-color': {
-      control: 'color',
-      description: 'The border color of the collapse'
-    },
-    '--leo-collapse-border-color-hover': {
-      control: 'color',
-      description: 'The border color of the collapse when hovered'
-    },
-    '--leo-collapse-shadow': {
-      type: 'string',
-      description: 'The shadow of the collapse'
-    },
-    '--leo-collapse-shadow-hover': {
-      type: 'string',
-      description: 'The shadow of the collapse when hovered'
-    },
-    '--leo-collapse-shadow-focus': {
-      type: 'string',
-      description: 'The shadow of the collapse when focused'
-    },
-    '--leo-collapse-radius': {
-      type: 'string',
-      description: 'The border radius of the collapse'
-    },
-    '--leo-collapse-summary-color': {
-      control: 'color',
-      description: 'The color of the summary text'
-    },
-    '--leo-collapse-summary-color-hover': {
-      control: 'color',
-      description: 'The color of the summary text when hovered'
-    },
-    '--leo-collapse-icon-color': {
-      control: 'color',
-      description: 'The color of the icons in the collapse'
-    },
-    '--leo-collapse-icon-color-hover': {
-      control: 'color',
-      description: 'The color of icons in the collapse in a hover state'
-    }
-  }}
-/>
 
 <Template let:args>
   <Collapse {...args} />

--- a/src/components/dialog/dialog.stories.svelte
+++ b/src/components/dialog/dialog.stories.svelte
@@ -1,7 +1,59 @@
-<script>
-  import { Meta, Story, Template } from '@storybook/addon-svelte-csf'
-
+<script context="module">
   import Dialog from './dialog.svelte'
+
+  export const meta = {
+    title: 'Components/Dialog',
+    component: Dialog,
+    argTypes: {
+      '--leo-dialog-width': {
+        'type': 'string',
+        'description': 'The CSS width of the dialog'
+      },
+      '--leo-dialog-padding': {
+        'type': 'string',
+        'description': 'The CSS padding of the dialog'
+      },
+      '--leo-dialog-border-radius': {
+        'type': 'string',
+        'description': 'The border radius of the dialog'
+      },
+      '--leo-dialog-background': {
+        'type': 'string',
+        'control': 'color',
+        'description': 'The background color of the dialog'
+      },
+      '--leo-dialog-color': {
+        'type': 'string',
+        'control': 'color',
+        'description': 'The default text color of the dialog'
+      },
+      '--leo-dialog-backdrop-background': {
+        'type': 'string',
+        'control': 'color',
+        'description': 'The color of the backdrop behind a modal dialog'
+      },
+      '--leo-dialog-backdrop-filter': {
+        'type': 'string',
+        'control': 'text',
+        'description': 'The filter to apply to the backdrop'
+      },
+      'isOpen': {
+        'control': 'none'
+      },
+      'size': {
+        'control': 'select',
+        'options': ['mobile', 'normal']
+      }
+    },
+    args: {
+      'isOpen': false
+    }
+  }
+</script>
+
+<script>
+  import { Story, Template } from '@storybook/addon-svelte-csf'
+
   import Button from '../button/button.svelte'
   import Alert from '../alert/alert.svelte'
   import '../dialogHelpers'
@@ -11,55 +63,6 @@
   let openDialog
   let isOpen = false
 </script>
-
-<Meta
-  title="Components/Dialog"
-  component={Dialog}
-  argTypes={{
-    '--leo-dialog-width': {
-      type: 'string',
-      description: 'The CSS width of the dialog'
-    },
-    '--leo-dialog-padding': {
-      type: 'string',
-      description: 'The CSS padding of the dialog'
-    },
-    '--leo-dialog-border-radius': {
-      type: 'string',
-      description: 'The border radius of the dialog'
-    },
-    '--leo-dialog-background': {
-      type: 'string',
-      control: 'color',
-      description: 'The background color of the dialog'
-    },
-    '--leo-dialog-color': {
-      type: 'string',
-      control: 'color',
-      description: 'The default text color of the dialog'
-    },
-    '--leo-dialog-backdrop-background': {
-      type: 'string',
-      control: 'color',
-      description: 'The color of the backdrop behind a modal dialog'
-    },
-    '--leo-dialog-backdrop-filter': {
-      type: 'string',
-      control: 'text',
-      description: 'The filter to apply to the backdrop'
-    },
-    isOpen: {
-      control: 'none'
-    },
-    size: {
-      control: 'select',
-      options: ['mobile', 'normal']
-    }
-  }}
-  args={{
-    isOpen: false
-  }}
-/>
 
 <Template let:args>
   <Button isDisabled={isOpen} onClick={() => (isOpen = true)}

--- a/src/components/dropdown/dropdown.stories.svelte
+++ b/src/components/dropdown/dropdown.stories.svelte
@@ -1,12 +1,36 @@
-<script lang="ts">
-  import { Meta, Story, Template } from '@storybook/addon-svelte-csf'
-
+<script context="module">
   import Dropdown from './dropdown.svelte'
+  import { modes, sizes } from '../formItem/formItem.svelte'
+
+  export const meta = {
+    title: 'Components/Dropdown',
+    component: Dropdown,
+    argTypes: {
+      '--leo-menu-control-width': {
+        description: '(readonly): Computed width of menu control'
+      },
+      size: {
+        control: 'select',
+        options: sizes
+      },
+      mode: {
+        control: 'select',
+        options: modes
+      }
+    },
+    args: {
+      label: 'Label',
+      placeholder: 'select...'
+    }
+  }
+</script>
+
+<script lang="ts">
+  import { Story, Template } from '@storybook/addon-svelte-csf'
+
   import Icon from '../icon/icon.svelte'
-  import { cssProperties, sizes } from '../formItem/formItem.svelte'
   import SlotInfo from '../../storyHelpers/SlotInfo.svelte'
   import Slot from '../../storyHelpers/Slot.svelte'
-  import { modes } from '../formItem/formItem.svelte'
 
   const countries = {
     'nz': 'New Zealand',
@@ -15,29 +39,6 @@
     'ca': 'Canada'
   }
 </script>
-
-<Meta
-  title="Components/Dropdown"
-  component={Dropdown}
-  argTypes={{
-    ...cssProperties,
-    '--leo-menu-control-width': {
-      description: '(readonly): Computed width of menu control'
-    },
-    size: {
-      control: 'select',
-      options: sizes
-    },
-    mode: {
-      control: 'select',
-      options: modes
-    }
-  }}
-  args={{
-    label: 'Label',
-    placeholder: 'select...'
-  }}
-/>
 
 <Template let:args>
   <div class="container">

--- a/src/components/icon/icon.stories.svelte
+++ b/src/components/icon/icon.stories.svelte
@@ -1,59 +1,64 @@
-<script>
-  import { Meta, Story, Template } from '@storybook/addon-svelte-csf'
-  import meta from '../../../icons/meta'
+<script context="module">
   import Icon from './icon.svelte'
+  import resources from '../../../icons/meta'
+
+  export const meta = {
+    title: 'Components/Icon',
+    component: Icon,
+    argTypes: {
+      '--leo-icon-color': {
+        control: 'color',
+        description: 'The color to use for the icon',
+        type: 'string'
+      },
+      '--leo-icon-size': {
+        control: 'text',
+        description: 'The size of the icon (defaults to 24px if not set)',
+        type: 'string'
+      },
+      '--leo-icon-height': {
+        control: 'text',
+        description:
+          'For irregular icon aspect ratios, you can set the height of the icon (defaults to 24px if not set)',
+        type: 'string'
+      },
+      '--leo-icon-width': {
+        control: 'text',
+        description:
+          'For irregular icon aspect ratios, you can set the width of the icon (defaults to 24px if not set)',
+        type: 'string'
+      },
+      name: {
+        control: 'select',
+        options: Object.values(resources.icons),
+        description: 'The name of the icon to use',
+        type: 'string'
+      },
+      color: {
+        control: 'color',
+        description:
+          'The current text color (this is used for the icon if --leo-icon-color is not set)',
+        type: 'string'
+      }
+    },
+    args: {
+      color: 'var(--leo-color-icon-default)',
+      name: 'shield-alert-filled',
+      '--leo-icon-size': '24px'
+    }
+  }
+</script>
+
+<script>
+  import { Story, Template } from '@storybook/addon-svelte-csf'
   import Slot from '../../storyHelpers/Slot.svelte'
   import SlotInfo from '../../storyHelpers/SlotInfo.svelte'
 
   let filter = ''
-  $: filteredIcons = Object.values(meta.icons).filter((i) =>
+  $: filteredIcons = Object.values(resources.icons).filter((i) =>
     i.toLowerCase().includes(filter.toLowerCase())
   )
 </script>
-
-<Meta
-  title="Components/Icon"
-  component={Icon}
-  argTypes={{
-    '--leo-icon-color': {
-      control: 'color',
-      description: 'The color to use for the icon',
-      type: 'string'
-    },
-    '--leo-icon-size': {
-      control: 'text',
-      description: 'The size of the icon (defaults to 24px if not set)',
-      type: 'string'
-    },
-    '--leo-icon-height': {
-      control: 'text',
-      description: 'For irregular icon aspect ratios, you can set the height of the icon (defaults to 24px if not set)',
-      type: 'string'
-    },
-    '--leo-icon-width': {
-      control: 'text',
-      description: 'For irregular icon aspect ratios, you can set the width of the icon (defaults to 24px if not set)',
-      type: 'string'
-    },
-    name: {
-      control: 'select',
-      options: Object.values(meta.icons),
-      description: 'The name of the icon to use',
-      type: 'string'
-    },
-    color: {
-      control: 'color',
-      description:
-        'The current text color (this is used for the icon if --leo-icon-color is not set)',
-      type: 'string'
-    }
-  }}
-  args={{
-    color: 'var(--leo-color-icon-default)',
-    name: 'shield-alert-filled',
-    '--leo-icon-size': '24px'
-  }}
-/>
 
 <Template let:args>
   <div style={`color: ${args.color}`}>

--- a/src/components/input/input.stories.svelte
+++ b/src/components/input/input.stories.svelte
@@ -1,46 +1,47 @@
-<script lang="ts">
-  import { Meta, Story, Template } from '@storybook/addon-svelte-csf'
-
+<script context="module">
   import Input from './input.svelte'
-  import Icon from '../icon/icon.svelte'
   import { cssProperties, modes, sizes } from '../formItem/formItem.svelte'
+
+  export const meta = {
+    title: 'Components/Input',
+    component: Input,
+    argTypes: {
+      ...cssProperties,
+      placeholder: {
+        type: 'string',
+        description: 'The placeholder'
+      },
+      label: {
+        type: 'string',
+        description: 'This is not a real prop of the component, it is just useful for configuring the storybook'
+      },
+      type: {
+        control: 'select',
+        options: ['text', 'password', 'date', 'time', 'color', 'number']
+      },
+      size: {
+        control: 'select',
+        options: sizes
+      },
+      mode: {
+        control: 'select',
+        options: modes
+      }
+    },
+    args: {
+      label: 'Label'
+    }
+  }
+</script>
+<script lang="ts">
+  import { Story, Template } from '@storybook/addon-svelte-csf'
+
+  import Icon from '../icon/icon.svelte'
   import SlotInfo from '../../storyHelpers/SlotInfo.svelte'
   import Slot from '../../storyHelpers/Slot.svelte'
 
   let characterCountValue = ''
 </script>
-
-<Meta
-  title="Components/Input"
-  component={Input}
-  argTypes={{
-    ...cssProperties,
-    placeholder: {
-      type: 'string',
-      description: 'The placeholder'
-    },
-    label: {
-      type: 'string',
-      description:
-        "This isn't a real prop of the component, it's just useful for configuring the storybook"
-    },
-    type: {
-      control: 'select',
-      options: ['text', 'password', 'date', 'time', 'color', 'number']
-    },
-    size: {
-      control: 'select',
-      options: sizes
-    },
-    mode: {
-      control: 'select',
-      options: modes
-    }
-  }}
-  args={{
-    label: 'Label'
-  }}
-/>
 
 <Template let:args>
   <Input {...args}>

--- a/src/components/label/label.stories.svelte
+++ b/src/components/label/label.stories.svelte
@@ -1,61 +1,65 @@
+<script context="module">
+  import Label from './label.svelte'
+
+  export const meta = {
+    title: 'Components/Label',
+    component: Label,
+    argTypes: {
+      color: {
+        control: 'select',
+        description: 'The color to use for the icon',
+        options: colors
+      },
+      mode: {
+        control: 'select',
+        options: modes,
+        description: 'The mode of the label'
+      },
+      storyLeftIcon: {
+        control: 'text',
+        description:
+          'Icon to the left of the label. This is only used for demonstration purposes',
+        type: 'text'
+      },
+      storyRightIcon: {
+        control: 'text',
+        description:
+          'Icon to the right of the label. This is only used for demonstration purposes',
+        type: 'text'
+      },
+      '--leo-label-icon-size': {
+        control: 'text',
+        description: 'The size of the icons (if any) inside the label',
+        type: 'number'
+      },
+      '--leo-label-font-text': {
+        control: 'text',
+        description: 'The font used for the label text',
+        type: 'text'
+      },
+      '--leo-label-padding': {
+        control: 'text',
+        description: 'The internal padding of the label',
+        type: 'text'
+      }
+    },
+    args: {
+      storyRightIcon: 'check-circle-outline',
+      storyLeftIcon: 'check-circle-outline',
+      mode: 'loud',
+      color: 'teal'
+    }
+  }
+</script>
+
 <script>
-  import { Meta, Story, Template } from '@storybook/addon-svelte-csf'
+  import { Story, Template } from '@storybook/addon-svelte-csf'
   import Icon from '../icon/icon.svelte'
 
-  import Label, { colors, modes } from './label.svelte'
+  import { colors, modes } from './label.svelte'
   import Slot from '../../storyHelpers/Slot.svelte'
   import SlotInfo from '../../storyHelpers/SlotInfo.svelte'
 </script>
-
-<Meta
-  title="Components/Label"
-  component={Label}
-  argTypes={{
-    color: {
-      control: 'select',
-      description: 'The color to use for the icon',
-      options: colors
-    },
-    mode: {
-      control: 'select',
-      options: modes,
-      description: 'The mode of the label'
-    },
-    storyLeftIcon: {
-      control: 'text',
-      description:
-        'Icon to the left of the label. This is only used for demonstration purposes',
-      type: 'text'
-    },
-    storyRightIcon: {
-      control: 'text',
-      description:
-        'Icon to the right of the label. This is only used for demonstration purposes',
-      type: 'text'
-    },
-    '--leo-label-icon-size': {
-      control: 'text',
-      description: 'The size of the icons (if any) inside the label',
-      type: 'number'
-    },
-    '--leo-label-font-text': {
-      control: 'text',
-      description: 'The font used for the label text',
-      type: 'text'
-    },
-    '--leo-label-padding': {
-      control: 'text',
-      description: 'The internal padding of the label',
-      type: 'text'
-    }
-  }}
-  args={{
-    storyRightIcon: 'check-circle-outline',
-    storyLeftIcon: 'check-circle-outline',
-    mode: 'loud',
-    color: 'teal'
-  }}
-/>
 
 <Template let:args>
   <Label {...args}>

--- a/src/components/link/link.stories.svelte
+++ b/src/components/link/link.stories.svelte
@@ -1,68 +1,71 @@
-<script>
-  import { Meta, Story, Template } from '@storybook/addon-svelte-csf'
-
+<script context="module">
   import Link from './link.svelte'
+
+  export const meta = {
+    title: 'Components/Link',
+    component: Link,
+    argTypes: {
+      href: {
+        control: 'text',
+        description: 'The href for the link',
+        type: 'string'
+      },
+      target: {
+        control: 'text',
+        description: 'The target for the link',
+        type: 'string'
+      },
+      text: {
+        control: 'text',
+        description: 'The text content of the link',
+        type: 'string'
+      },
+      '--leo-link-color': {
+        type: 'string',
+        control: 'color',
+        description: 'The color of the link'
+      },
+      '--leo-link-hover-color': {
+        type: 'string',
+        control: 'color',
+        description: 'The hover color of the link'
+      },
+      '--leo-link-visited-color': {
+        type: 'string',
+        control: 'color',
+        description: 'The visited color of the link'
+      },
+      '--leo-link-disabled-color': {
+        type: 'string',
+        control: 'color',
+        description: 'The disabled color of the link'
+      },
+      '--leo-link-focus-color': {
+        type: 'string',
+        control: 'color',
+        description:
+          'The focused color of the link. Defaults to the link color, if not set'
+      },
+      '--leo-link-focus-shadow': {
+        type: 'string',
+        control: 'text',
+        description: 'The focused shadow for the link'
+      }
+    },
+    args: {
+      text: 'Download Brave',
+      target: '_blank',
+      href: 'https://brave.com'
+    }
+  }
+</script>
+
+<script>
+  import { Story, Template } from '@storybook/addon-svelte-csf'
+
   import SlotInfo from '../../storyHelpers/SlotInfo.svelte'
   import Slot from '../../storyHelpers/Slot.svelte'
 </script>
-
-<Meta
-  title="Components/Link"
-  component={Link}
-  argTypes="{{
-    href: {
-      control: 'text',
-      description: 'The href for the link',
-      type: 'string'
-    },
-    target: {
-      control: 'text',
-      description: 'The target for the link',
-      type: 'string'
-    },
-    text: {
-      control: 'text',
-      description: 'The text content of the link',
-      type: 'string'
-    },
-    '--leo-link-color': {
-      type: 'string',
-      control: 'color',
-      description: 'The color of the link'
-    },
-    '--leo-link-hover-color': {
-      type: 'string',
-      control: 'color',
-      description: 'The hover color of the link'
-    },
-    '--leo-link-visited-color': {
-      type: 'string',
-      control: 'color',
-      description: 'The visited color of the link'
-    },
-    '--leo-link-disabled-color': {
-      type: 'string',
-      control: 'color',
-      description: 'The disabled color of the link'
-    },
-    '--leo-link-focus-color': {
-      type: 'string',
-      control: 'color',
-      description:
-        'The focused color of the link. Defaults to the link color, if not set'
-    },
-    '--leo-link-focus-shadow': {
-      type: 'string',
-      control: 'text',
-      description: 'The focused shadow for the link'
-    }
-  }},"
-  args={{
-    text: 'Download Brave',
-    target: '_blank',
-    href: 'https://brave.com'
-  }}
-/>
 
 <Template let:args>
   <Link href="#foo" {...args} />

--- a/src/components/navdots/navdots.stories.svelte
+++ b/src/components/navdots/navdots.stories.svelte
@@ -1,6 +1,61 @@
-<script lang="ts">
-  import { Meta, Story, Template } from '@storybook/addon-svelte-csf'
+<script context="module">
   import NavDots from './navdots.svelte'
+
+  export const meta = {
+    title: 'Components/Nav Dots',
+    component: NavDots,
+    argTypes: {
+      dotCount: { control: 'number' },
+      '--leo-navdots-size': {
+        type: 'string',
+        description: 'The size of the navdots (a CSS unit)'
+      },
+      '--leo-navdots-expanded-size': {
+        type: 'string',
+        description: 'The size of the expanded navdot'
+      },
+      '--leo-navdots-spacing': {
+        type: 'string',
+        description: 'The space between the individual dots'
+      },
+      '--leo-navdots-vertical-margin': {
+        type: 'string',
+        description: 'The margin above and below the navdots'
+      },
+      '--leo-navdots-transition-duration': {
+        type: 'string',
+        description:
+          'The amount of time it takes for the dot to slide into position. Only used if animateSlide is true'
+      },
+      '--leo-navdots-transition-easing': {
+        type: 'string',
+        description: 'The easing function for the slide animation'
+      },
+      '--leo-navdots-active-color': {
+        control: 'color',
+        description: 'The color of the active dot'
+      },
+      '--leo-navdots-active-color-hover': {
+        control: 'color',
+        description: 'The color of the active dot when hovering'
+      },
+      '--leo-navdots-color': {
+        control: 'color',
+        description: 'The color of the non-active dots'
+      },
+      '--leo-navdots-color-hover': {
+        control: 'color',
+        description: 'The color of the non-active dots when hovering'
+      }
+    },
+    args: {
+      dotCount: 10
+    }
+  }
+</script>
+
+<script lang="ts">
+  import { Story, Template } from '@storybook/addon-svelte-csf'
   import SlotInfo from '../../storyHelpers/SlotInfo.svelte'
 
   let activeDot = 0
@@ -8,59 +63,6 @@
     activeDot = n.detail.activeDot
   }
 </script>
-
-<Meta
-  title="Components/Nav Dots"
-  component={NavDots}
-  argTypes={{
-    dotCount: { control: 'number' },
-
-    '--leo-navdots-size': {
-      type: 'string',
-      description: 'The size of the navdots (a CSS unit)'
-    },
-    '--leo-navdots-expanded-size': {
-      type: 'string',
-      description: 'The size of the expanded navdot'
-    },
-    '--leo-navdots-spacing': {
-      type: 'string',
-      description: 'The space between the individual dots'
-    },
-    '--leo-navdots-vertical-margin': {
-      type: 'string',
-      description: 'The margin above and below the navdots'
-    },
-    '--leo-navdots-transition-duration': {
-      type: 'string',
-      description:
-        'The amount of time it takes for the dot to slide into position. Only used if animateSlide is true'
-    },
-    '--leo-navdots-transition-easing': {
-      type: 'string',
-      description: 'The easing function for the slide animation'
-    },
-    '--leo-navdots-active-color': {
-      control: 'color',
-      description: 'The color of the active dot'
-    },
-    '--leo-navdots-active-color-hover': {
-      control: 'color',
-      description: 'The color of the active dot when hovering'
-    },
-    '--leo-navdots-color': {
-      control: 'color',
-      description: 'The color of the non-active dots'
-    },
-    '--leo-navdots-color-hover': {
-      control: 'color',
-      description: 'The color of the non-active dots when hovering'
-    }
-  }}
-  args={{
-    dotCount: 10
-  }}
-/>
 
 <Template let:args>
   <NavDots {activeDot} onChange={handleChange} {...args} />

--- a/src/components/navigation/navigation.stories.svelte
+++ b/src/components/navigation/navigation.stories.svelte
@@ -1,18 +1,5 @@
-<script lang="ts">
-  import { Meta, Story, Template } from '@storybook/addon-svelte-csf'
-
+<script context="module" lang="ts">
   import Navigation from './navigation.svelte'
-  import NavigationItem from './navigationItem.svelte'
-  import NavigationHeader from './navigationHeader.svelte'
-  import NavigationActions from './navigationActions.svelte'
-  import Hr from '../hr/hr.svelte'
-  import NavigationMenu from './navigationMenu.svelte'
-  import Icon from '../icon/icon.svelte'
-  import SlotInfo from '../../storyHelpers/SlotInfo.svelte'
-  import Slot from '../../storyHelpers/Slot.svelte'
-  import SegmentedControl from '../segmentedControl/segmentedControl.svelte'
-  import ControlItem from '../controlItem/controlItem.svelte'
-  import type { IconName } from '../../../icons/meta'
 
   type MenuItem = {
     icon: IconName
@@ -82,27 +69,43 @@
 
   const allUrls = getUrls(menuItems)
 
-  let theme = 'light'
+  export const meta = {
+    title: 'Components/Navigation',
+    component: Navigation,
+    argTypes: {
+      current: {
+        control: 'select',
+        options: allUrls
+      },
+      kind: {
+        table: {
+          disable: true
+        }
+      }
+    },
+    args: {
+      current: allUrls[0]
+    }
+  }
 </script>
 
-<Meta
-  title="Components/Navigation"
-  component={Navigation}
-  argTypes={{
-    current: {
-      control: 'select',
-      options: allUrls
-    },
-    kind: {
-      table: {
-        disable: true
-      }
-    }
-  }}
-  args={{
-    current: allUrls[0]
-  }}
-/>
+<script lang="ts">
+  import { Story, Template } from '@storybook/addon-svelte-csf'
+
+  import NavigationItem from './navigationItem.svelte'
+  import NavigationHeader from './navigationHeader.svelte'
+  import NavigationActions from './navigationActions.svelte'
+  import Hr from '../hr/hr.svelte'
+  import NavigationMenu from './navigationMenu.svelte'
+  import Icon from '../icon/icon.svelte'
+  import SlotInfo from '../../storyHelpers/SlotInfo.svelte'
+  import Slot from '../../storyHelpers/Slot.svelte'
+  import SegmentedControl from '../segmentedControl/segmentedControl.svelte'
+  import ControlItem from '../controlItem/controlItem.svelte'
+  import type { IconName } from '../../../icons/meta'
+
+  let theme = 'light'
+</script>
 
 <Template let:args>
   <div class="container">

--- a/src/components/progress/progressBar.stories.svelte
+++ b/src/components/progress/progressBar.stories.svelte
@@ -1,38 +1,41 @@
-<script lang="ts">
-  import { Meta, Story } from '@storybook/addon-svelte-csf'
+<script context="module">
   import Bar from './progressBar.svelte'
-  import SlotInfo from '../../storyHelpers/SlotInfo.svelte'
+
+  export const meta = {
+    title: 'Components/Progress Bar',
+    component: Bar,
+    argTypes: {
+      '--leo-progressbar-radius': {
+        type: 'string',
+        description: 'The border radius of the progress bar'
+      },
+      '--leo-progressbar-height': {
+        type: 'string',
+        description: 'The height of the progress bar'
+      },
+      '--leo-progressbar-background-color': {
+        type: 'string',
+        control: 'color',
+        description: 'The background color of the progress bar'
+      },
+      '--leo-progressbar-color': {
+        type: 'string',
+        control: 'color',
+        description: 'The color of the progress on the progress bar'
+      }
+    }
+  }
 </script>
 
-<Meta
-  title="Components/Progress Bar"
-  component={Bar}
-  argTypes={{
-    '--leo-progressbar-radius': {
-      type: 'string',
-      description: 'The border radius of the progress bar'
-    },
-    '--leo-progressbar-height': {
-      type: 'string',
-      description: 'The height of the progress bar'
-    },
-    '--leo-progressbar-background-color': {
-      type: 'string',
-      control: 'color',
-      description: 'The background color of the progress bar'
-    },
-    '--leo-progressbar-color': {
-      type: 'string',
-      control: 'color',
-      description: 'The color of the progress on the progress bar'
-    }
-  }}
-/>
+<script lang="ts">
+  import { Story } from '@storybook/addon-svelte-csf'
+  import SlotInfo from '../../storyHelpers/SlotInfo.svelte'
+</script>
 
 <Story name="Slots">
   <SlotInfo description="The progress bar has no slots" />
 </Story>
 
-<Story name="Bar" let:args>
+<Story name="Default Bar" let:args>
   <Bar {...args} />
 </Story>

--- a/src/components/progress/progressRing.stories.svelte
+++ b/src/components/progress/progressRing.stories.svelte
@@ -1,49 +1,52 @@
-<script lang="ts">
-  import { Meta, Story } from '@storybook/addon-svelte-csf'
+<script context="module">
   import Ring from './progressRing.svelte'
+
+  export const meta = {
+    title: 'Components/Progress Ring',
+    component: Ring,
+    argTypes: {
+      '--leo-progressring-spin-rate': {
+        type: 'string',
+        description: 'The rate that the indeterminate spinner spins at'
+      },
+      '--leo-progressring-color': {
+        type: 'string',
+        control: 'color',
+        description: 'The color of the progress on the progress ring'
+      },
+      '--leo-progressring-size': {
+        type: 'string',
+        description: 'The size of the progress ring'
+      },
+      progress: {
+        control: {
+          type: 'number',
+          min: 0,
+          max: 1,
+          step: 0.1
+        },
+        description: 'A number between 0 and 1 to describe current progress'
+      },
+      mode: {
+        type: 'string',
+        description: 'The mode of the progress indicator',
+        control: 'select',
+        options: ['determinate', 'indeterminate']
+      }
+    },
+    args: {
+      mode: 'indeterminate'
+    }
+  }
+</script>
+
+<script lang="ts">
+  import { Story } from '@storybook/addon-svelte-csf'
   import Icon from '../icon/icon.svelte'
   import SlotInfo from '../../storyHelpers/SlotInfo.svelte'
   import Slot from '../../storyHelpers/Slot.svelte'
   import ProgressRing from './progressRing.svelte'
 </script>
-
-<Meta
-  title="Components/Progress Ring"
-  component={Ring}
-  argTypes={{
-    '--leo-progressring-spin-rate': {
-      type: 'string',
-      description: 'The rate that the indeterminate spinner spins at'
-    },
-    '--leo-progressring-color': {
-      type: 'string',
-      control: 'color',
-      description: 'The color of the progress on the progress ring'
-    },
-    '--leo-progressring-size': {
-      type: 'string',
-      description: 'The size of the progress ring'
-    },
-    progress: {
-      control: {
-        type: 'number',
-        min: 0,
-        max: 1,
-        step: 0.1
-      },
-      description: 'A number between 0 and 1 to describe current progress'
-    },
-    mode: {
-      type: 'string',
-      description: 'The mode of the progress indicator',
-      control: 'select',
-      options: ['determinate', 'indeterminate']
-    }
-  }}
-  args={{
-    mode: 'indeterminate'
-  }}
-/>
 
 <Story name="Slots" let:args>
   <SlotInfo
@@ -59,6 +62,6 @@
   </SlotInfo>
 </Story>
 
-<Story name="Ring" let:args>
+<Story name="Default Ring" let:args>
   <Ring {...args} />
 </Story>

--- a/src/components/radioButton/radioButton.stories.svelte
+++ b/src/components/radioButton/radioButton.stories.svelte
@@ -1,92 +1,95 @@
-<script lang="ts">
-  import { Meta, Story, Template } from '@storybook/addon-svelte-csf'
+<script context="module">
   import RadioButton, { sizes } from './radioButton.svelte'
+
+  export const meta = {
+    title: 'Components/Radio Button',
+    component: RadioButton,
+    argTypes: {
+      '--leo-radiobutton-focus-border-radius': {
+        control: 'text',
+        type: 'string',
+        description: 'The border radius of the focus shadow'
+      },
+      '--leo-radiobutton-label-gap': {
+        control: 'text',
+        type: 'string',
+        description: 'The gap between the label and the checkbox'
+      },
+      '--leo-radiobutton-flex-direction': {
+        control: 'select',
+        description: 'The flex direction of the label/button',
+        options: ['row', 'row-reverse', 'column', 'column-reverse']
+      },
+      '--leo-radiobutton-checked-color': {
+        control: 'color',
+        type: 'string',
+        description: 'The color of the checkbox when checked'
+      },
+      '--leo-radiobutton-checked-color-hover': {
+        control: 'color',
+        type: 'string',
+        description: 'The color of the checkbox when checked and hovered'
+      },
+      '--leo-radiobutton-unchecked-color': {
+        control: 'color',
+        type: 'string',
+        description: 'The color of the checkbox when unchecked'
+      },
+      '--leo-radiobutton-unchecked-color-hover': {
+        control: 'color',
+        type: 'string',
+        description: 'The color of the checkbox when unchecked and hovered'
+      },
+      '--leo-radiobutton-font': {
+        control: 'text',
+        type: 'string',
+        description: 'The font to use for the label'
+      },
+      '--leo-radiobutton-disabled-color': {
+        control: 'color',
+        type: 'string',
+        description: 'The color of the checkbox + label when disabled'
+      },
+      name: {
+        control: 'text',
+        description:
+          'The name of the group of radio buttons (i.e. the name of the property the buttons are selecting for).'
+      },
+      isDisabled: {
+        control: 'boolean',
+        description: 'Whether the control is disabled'
+      },
+      size: {
+        control: 'select',
+        options: sizes,
+        description: 'The size of the control'
+      },
+      value: {
+        control: null,
+        description:
+          'This is the value |currentValue| will be when the radio is selected'
+      },
+      currentValue: {
+        control: null,
+        description:
+          'The current value of the control. In Svelte, this can be bound. WebComponents can also manage it automatically. The checked event is fired with the new value when the current value changes.'
+      }
+    },
+    args: {
+      size: 'normal',
+      isDisabled: false,
+      name: 'options'
+    }
+  }
+</script>
+
+<script lang="ts">
+  import { Story, Template } from '@storybook/addon-svelte-csf'
   import SlotInfo from '../../storyHelpers/SlotInfo.svelte'
   import Slot from '../../storyHelpers/Slot.svelte'
 
   let currentValue = 'hello'
 </script>
-
-<Meta
-  title="Components/Radio Button"
-  component={RadioButton}
-  argTypes={{
-    '--leo-radiobutton-focus-border-radius': {
-      control: 'text',
-      type: 'string',
-      description: 'The border radius of the focus shadow'
-    },
-    '--leo-radiobutton-label-gap': {
-      control: 'text',
-      type: 'string',
-      description: 'The gap between the label and the checkbox'
-    },
-    '--leo-radiobutton-flex-direction': {
-      control: 'select',
-      description: 'The flex direction of the label/button',
-      options: ['row', 'row-reverse', 'column', 'column-reverse']
-    },
-    '--leo-radiobutton-checked-color': {
-      control: 'color',
-      type: 'string',
-      description: 'The color of the checkbox when checked'
-    },
-    '--leo-radiobutton-checked-color-hover': {
-      control: 'color',
-      type: 'string',
-      description: 'The color of the checkbox when checked and hovered'
-    },
-    '--leo-radiobutton-unchecked-color': {
-      control: 'color',
-      type: 'string',
-      description: 'The color of the checkbox when unchecked'
-    },
-    '--leo-radiobutton-unchecked-color-hover': {
-      control: 'color',
-      type: 'string',
-      description: 'The color of the checkbox when unchecked and hovered'
-    },
-    '--leo-radiobutton-font': {
-      control: 'text',
-      type: 'string',
-      description: 'The font to use for the label'
-    },
-    '--leo-radiobutton-disabled-color': {
-      control: 'color',
-      type: 'string',
-      description: 'The color of the checkbox + label when disabled'
-    },
-    name: {
-      control: 'text',
-      description:
-        'The name of the group of radio buttons (i.e. the name of the property the buttons are selecting for).'
-    },
-    isDisabled: {
-      control: 'boolean',
-      description: 'Whether the control is disabled'
-    },
-    size: {
-      control: 'select',
-      options: sizes,
-      description: 'The size of the control'
-    },
-    value: {
-      control: null,
-      description:
-        'This is the value |currentValue| will be when the radio is selected'
-    },
-    currentValue: {
-      control: null,
-      description:
-        'The current value of the control. In Svelte, this can be bound. WebComponents can also manage it automatically. The checked event is fired with the new value when the current value changes.'
-    }
-  }}
-  args={{
-    size: 'normal',
-    isDisabled: false,
-    name: 'options'
-  }}
-/>
 
 <Template let:args>
   <RadioButton {...args} name={args.name} bind:currentValue value={'hello'}

--- a/src/components/segmentedControl/segmentedControl.stories.svelte
+++ b/src/components/segmentedControl/segmentedControl.stories.svelte
@@ -1,96 +1,100 @@
+<script context="module">
+  import SegmentedControl, {
+    segmentedControlSizes
+  } from './segmentedControl.svelte'
+
+  export const meta = {
+    title: 'Components/SegmentedControl',
+    component: SegmentedControl,
+    argTypes: {
+      '--leo-segmented-control-width': {
+        control: 'text',
+        type: 'string',
+        description:
+          'The width for the entire control (defaults to `fit-content`).'
+      },
+      '--leo-control-padding': {
+        control: 'text',
+        type: 'string',
+        description: 'The padding for the entire control.'
+      },
+      '--leo-control-item-radius': {
+        control: 'text',
+        type: 'string',
+        description: 'The radius for the individual control items.'
+      },
+      '--leo-control-item-height': {
+        control: 'text',
+        type: 'string',
+        description: 'The height for the individual control items.'
+      },
+      '--leo-control-item-padding': {
+        control: 'text',
+        type: 'string',
+        description: 'The padding for the individual control items.'
+      },
+      '--leo-control-item-color': {
+        control: 'text',
+        type: 'string',
+        description: 'The text color for the individual control items.'
+      },
+      '--leo-control-item-font': {
+        control: 'text',
+        type: 'string',
+        description:
+          'The font (shorthand CSS property) for the individual control items.'
+      },
+      '--leo-control-item-background': {
+        control: 'text',
+        type: 'string',
+        description: 'The background color for the individual control items.'
+      },
+      '--leo-control-item-shadow': {
+        control: 'text',
+        type: 'string',
+        description:
+          "The box shadow for the individual control items' hover state."
+      },
+      '--leo-control-item-icon-color': {
+        control: 'text',
+        type: 'string',
+        description: 'The icon color for the individual control items.'
+      },
+      '--leo-control-item-icon-gap': {
+        control: 'text',
+        type: 'string',
+        description:
+          'The gap between icon and content for the individual control items.'
+      },
+      size: {
+        control: 'select',
+        options: segmentedControlSizes
+      },
+      value: {
+        table: {
+          disable: true
+        }
+      },
+      segmentedControlSizes: {
+        table: {
+          disable: true
+        }
+      }
+    },
+    args: {}
+  }
+</script>
+
 <script>
-  import { Meta, Story, Template } from '@storybook/addon-svelte-csf'
+  import { Story, Template } from '@storybook/addon-svelte-csf'
 
   import Slot from '../../storyHelpers/Slot.svelte'
   import SlotInfo from '../../storyHelpers/SlotInfo.svelte'
   import ControlItem from '../controlItem/controlItem.svelte'
   import Icon from '../icon/icon.svelte'
-  import SegmentedControl, {
-    segmentedControlSizes
-  } from './segmentedControl.svelte'
 
   let selected = 'full'
 </script>
-
-<Meta
-  title="Components/SegmentedControl"
-  component={SegmentedControl}
-  argTypes={{
-    '--leo-segmented-control-width': {
-      control: 'text',
-      type: 'string',
-      description: 'The width for the entire control (defaults to `fit-content`).'
-    },
-    '--leo-control-padding': {
-      control: 'text',
-      type: 'string',
-      description: 'The padding for the entire control.'
-    },
-    '--leo-control-item-radius': {
-      control: 'text',
-      type: 'string',
-      description: 'The radius for the individual control items.'
-    },
-    '--leo-control-item-height': {
-      control: 'text',
-      type: 'string',
-      description: 'The height for the individual control items.'
-    },
-    '--leo-control-item-padding': {
-      control: 'text',
-      type: 'string',
-      description: 'The padding for the individual control items.'
-    },
-    '--leo-control-item-color': {
-      control: 'text',
-      type: 'string',
-      description: 'The text color for the individual control items.'
-    },
-    '--leo-control-item-font': {
-      control: 'text',
-      type: 'string',
-      description:
-        'The font (shorthand CSS property) for the individual control items.'
-    },
-    '--leo-control-item-background': {
-      control: 'text',
-      type: 'string',
-      description: 'The background color for the individual control items.'
-    },
-    '--leo-control-item-shadow': {
-      control: 'text',
-      type: 'string',
-      description:
-        "The box shadow for the individual control items' hover state."
-    },
-    '--leo-control-item-icon-color': {
-      control: 'text',
-      type: 'string',
-      description: 'The icon color for the individual control items.'
-    },
-    '--leo-control-item-icon-gap': {
-      control: 'text',
-      type: 'string',
-      description:
-        'The gap between icon and content for the individual control items.'
-    },
-    size: {
-      control: 'select',
-      options: segmentedControlSizes
-    },
-    value: {
-      table: {
-        disable: true
-      }
-    },
-    segmentedControlSizes: {
-      table: {
-        disable: true
-      }
-    }
-  }}
-  args={{}}
-/>
 
 <Template let:args>
   <p>Selected item: <code>{selected}</code></p>

--- a/src/components/textarea/textarea.stories.svelte
+++ b/src/components/textarea/textarea.stories.svelte
@@ -1,38 +1,41 @@
-<script lang="ts">
-  import { Meta, Story, Template } from '@storybook/addon-svelte-csf'
-
+<script context="module">
   import TextArea from './textarea.svelte'
+  import { cssProperties, modes } from '../formItem/formItem.svelte'
+
+  export const meta = {
+    title: 'Components/TextArea',
+    component: TextArea,
+    argTypes: {
+      ...cssProperties,
+      placeholder: {
+        type: 'string',
+        description: 'The placeholder'
+      },
+      label: {
+        type: 'string',
+        description:
+          "This isn't a real prop of the component, it's just useful for configuring the storybook"
+      },
+      mode: {
+        control: 'select',
+        options: modes
+      }
+    },
+    args: {
+      label: 'Label'
+    }
+  }
+</script>
+
+<script lang="ts">
+  import { Story, Template } from '@storybook/addon-svelte-csf'
+
   import Icon from '../icon/icon.svelte'
-  import { cssProperties, modes, sizes } from '../formItem/formItem.svelte'
   import SlotInfo from '../../storyHelpers/SlotInfo.svelte'
   import Slot from '../../storyHelpers/Slot.svelte'
 
   let characterCountValue = ''
 </script>
-
-<Meta
-  title="Components/TextArea"
-  component={TextArea}
-  argTypes={{
-    ...cssProperties,
-    placeholder: {
-      type: 'string',
-      description: 'The placeholder'
-    },
-    label: {
-      type: 'string',
-      description:
-        "This isn't a real prop of the component, it's just useful for configuring the storybook"
-    },
-    mode: {
-      control: 'select',
-      options: modes
-    }
-  }}
-  args={{
-    label: 'Label'
-  }}
-/>
 
 <Template let:args>
   <TextArea {...args}>
@@ -49,7 +52,7 @@
 </Story>
 
 <Story name="minRows/maxRows" let:args>
-  <TextArea {...args} minRows=1 maxRows=3>
+  <TextArea {...args} minRows="1" maxRows="3">
     {args.label}
   </TextArea>
 </Story>

--- a/src/components/toggle/toggle.stories.svelte
+++ b/src/components/toggle/toggle.stories.svelte
@@ -1,75 +1,77 @@
-<script lang="ts">
-  import { Meta, Story, Template } from '@storybook/addon-svelte-csf'
-  import Icon from '../icon/icon.svelte'
+<script context="module">
   import Toggle, { sizes } from './toggle.svelte'
+
+  export const meta = {
+    title: 'Components/Toggle',
+    component: Toggle,
+    argTypes: {
+      '--leo-toggle-transition-duration': {
+        type: 'string',
+        description: 'The duration of the change animation'
+      },
+      '--leo-toggle-width': {
+        type: 'string',
+        description: 'The width of the toggle (in CSS units)'
+      },
+      '--leo-toggle-height': {
+        type: 'string',
+        description: 'The height of the toggle (in CSS units)'
+      },
+      '--leo-toggle-padding': {
+        type: 'string',
+        description: 'The padding of the toggle'
+      },
+      '--leo-toggle-checked-color': {
+        control: 'color',
+        description: 'The background color of the toggle when checked'
+      },
+      '--leo-toggle-checked-color-hover': {
+        control: 'color',
+        description:
+          'The background color of the toggle when checked and hovering'
+      },
+      '--leo-toggle-unchecked-color': {
+        control: 'color',
+        description: 'The background color of the toggle when not checked'
+      },
+      '--leo-toggle-unchecked-color-hover': {
+        control: 'color',
+        description:
+          'The background color of the toggle when not checked and hovering'
+      },
+      '--leo-toggle-thumb-color': {
+        control: 'color',
+        description: 'The color of the thumb'
+      },
+      '--leo-toggle-thumb-disabled-color': {
+        control: 'color',
+        description: 'The color of the thumb when the control is disabled'
+      },
+      '--leo-toggle-label-gap': {
+        description: 'The space between the label and the toggle (in CSS units)'
+      },
+      '--leo-toggle-label-flex-direction': {
+        control: 'select',
+        options: ['row', 'row-reverse', 'column', 'column-reverse'],
+        description:
+          'Controls how the label is laid out in relation to the toggle.'
+      },
+      size: { control: 'select', options: sizes },
+      label: { control: 'text' }
+    },
+    args: {
+      label: 'Label',
+      size: 'medium'
+    }
+  }
+</script>
+
+<script lang="ts">
+  import { Story, Template } from '@storybook/addon-svelte-csf'
+  import Icon from '../icon/icon.svelte'
   import SlotInfo from '../../storyHelpers/SlotInfo.svelte'
   import Slot from '../../storyHelpers/Slot.svelte'
 </script>
-
-<Meta
-  title="Components/Toggle"
-  component={Toggle}
-  argTypes={{
-    '--leo-toggle-transition-duration': {
-      type: 'string',
-      description: 'The duration of the change animation'
-    },
-    '--leo-toggle-width': {
-      type: 'string',
-      description: 'The width of the toggle (in CSS units)'
-    },
-    '--leo-toggle-height': {
-      type: 'string',
-      description: 'The height of the toggle (in CSS units)'
-    },
-    '--leo-toggle-padding': {
-      type: 'string',
-      description: 'The padding of the toggle'
-    },
-    '--leo-toggle-checked-color': {
-      control: 'color',
-      description: 'The background color of the toggle when checked'
-    },
-    '--leo-toggle-checked-color-hover': {
-      control: 'color',
-      description:
-        'The background color of the toggle when checked and hovering'
-    },
-    '--leo-toggle-unchecked-color': {
-      control: 'color',
-      description: 'The background color of the toggle when not checked'
-    },
-    '--leo-toggle-unchecked-color-hover': {
-      control: 'color',
-      description:
-        'The background color of the toggle when not checked and hovering'
-    },
-    '--leo-toggle-thumb-color': {
-      control: 'color',
-      description: 'The color of the thumb'
-    },
-    '--leo-toggle-thumb-disabled-color': {
-      control: 'color',
-      description: 'The color of the thumb when the control is disabled'
-    },
-    '--leo-toggle-label-gap': {
-      description: 'The space between the label and the toggle (in CSS units)'
-    },
-    '--leo-toggle-label-flex-direction': {
-      control: 'select',
-      options: ['row', 'row-reverse', 'column', 'column-reverse'],
-      description:
-        'Controls how the label is laid out in relation to the toggle.'
-    },
-
-    size: { control: 'select', options: sizes },
-    label: { control: 'text' }
-  }}
-  args={{
-    label: 'Label',
-    size: 'medium'
-  }}
-/>
 
 <Template let:args>
   <Toggle {...args}>{args.label}</Toggle>

--- a/src/components/tooltip/tooltip.stories.svelte
+++ b/src/components/tooltip/tooltip.stories.svelte
@@ -1,53 +1,56 @@
-<script lang="ts">
-  import { Meta, Story, Template } from '@storybook/addon-svelte-csf'
-  import SlotInfo from '../../storyHelpers/SlotInfo.svelte'
-  import Slot from '../../storyHelpers/Slot.svelte'
+<script context="module">
   import Tooltip, { modes } from './tooltip.svelte'
-  import Button from '../button/button.svelte'
-  import Checkbox from '../checkbox/checkbox.svelte'
-  import Icon from '../icon/icon.svelte'
 
   const strategies = ['absolute', 'fixed']
   const sides = ['top', 'bottom', 'left', 'right']
   const positions = ['', '-start', '-end']
   const placements = positions.flatMap((p) => sides.map((s) => `${s}${p}`))
 
-  let showTooltip = true
+  export const meta = {
+    title: 'Components/Tooltip',
+    component: Tooltip,
+    argTypes: {
+      '--leo-tooltip-padding': {
+        type: 'string',
+        description: 'The internal padding on the tooltip'
+      },
+      '--leo-tooltip-text-color': {
+        type: 'string',
+        control: 'color',
+        description: 'The text color for the tooltip'
+      },
+      '--leo-tooltip-background': {
+        type: 'string',
+        control: 'color',
+        description: 'The background color of the tooltip'
+      },
+      '--leo-tooltip-shadow': {
+        type: 'string',
+        description: 'The shadow effect for the tooltip'
+      },
+      text: { control: 'text' },
+      mode: { control: 'select', options: modes },
+      placement: { control: 'select', options: placements },
+      fallbackPlacements: { control: 'multi-select', options: placements },
+      positionStrategy: { control: 'select', options: strategies }
+    },
+    args: {
+      text: 'A helpful hint',
+      mode: 'default'
+    }
+  }
 </script>
 
-<Meta
-  title="Components/Tooltip"
-  component={Tooltip}
-  argTypes={{
-    '--leo-tooltip-padding': {
-      type: 'string',
-      description: 'The internal padding on the tooltip'
-    },
-    '--leo-tooltip-text-color': {
-      type: 'string',
-      control: 'color',
-      description: 'The text color for the tooltip'
-    },
-    '--leo-tooltip-background': {
-      type: 'string',
-      control: 'color',
-      description: 'The background color of the tooltip'
-    },
-    '--leo-tooltip-shadow': {
-      type: 'string',
-      description: 'The shadow effect for the tooltip'
-    },
-    text: { control: 'text' },
-    mode: { control: 'select', options: modes },
-    placement: { control: 'select', options: placements },
-    fallbackPlacements: { control: 'multi-select', options: placements },
-    positionStrategy: { control: 'select', options: strategies }
-  }}
-  args={{
-    text: 'A helpful hint',
-    mode: 'default'
-  }}
-/>
+<script lang="ts">
+  import { Story, Template } from '@storybook/addon-svelte-csf'
+  import SlotInfo from '../../storyHelpers/SlotInfo.svelte'
+  import Slot from '../../storyHelpers/Slot.svelte'
+  import Button from '../button/button.svelte'
+  import Checkbox from '../checkbox/checkbox.svelte'
+  import Icon from '../icon/icon.svelte'
+
+  let showTooltip = true
+</script>
 
 <Template let:args>
   <Tooltip {...args}>

--- a/src/tokens/browserFontTokens.stories.svelte
+++ b/src/tokens/browserFontTokens.stories.svelte
@@ -1,14 +1,17 @@
+<script context="module">
+  export const meta = {
+    title: 'Tokens/Browser/Fonts'
+  }
+</script>
 <script lang="ts">
   import { onMount } from 'svelte'
-  import { Meta, Story } from '@storybook/addon-svelte-csf'
+  import { Story } from '@storybook/addon-svelte-csf'
   import { font as allFonts } from '../../tokens/css/variables-browser'
   import FontTokenSwatchGroup from '../storyHelpers/FontTokenSwatchGroup.svelte'
   import { scopedApplyLayer } from '../../.storybook/global.svelte'
 
   onMount(() => scopedApplyLayer("variables-browser"))
 </script>
-
-<Meta title="Tokens/Browser/Fonts" />
 
 <Story name="All Fonts">
   <FontTokenSwatchGroup tokens={allFonts} />

--- a/src/tokens/marketingFontTokens.stories.svelte
+++ b/src/tokens/marketingFontTokens.stories.svelte
@@ -1,6 +1,11 @@
+<script context="module">
+  export const meta = {
+    title: 'Tokens/Marketing/Fonts'
+  }
+</script>
 <script lang="ts">
   import { onMount } from 'svelte'
-  import { Meta, Story } from '@storybook/addon-svelte-csf'
+  import { Story } from '@storybook/addon-svelte-csf'
   import { font as allFonts } from '../../tokens/css/variables-marketing'
   import FontTokenSwatchGroup from '../storyHelpers/FontTokenSwatchGroup.svelte'
   import { scopedApplyLayer } from '../../.storybook/global.svelte'
@@ -9,8 +14,6 @@
 
   const { mobile, desktop } = allFonts
 </script>
-
-<Meta title="Tokens/Marketing/Fonts" />
 
 <Story name="Desktop/Tablet">
   <FontTokenSwatchGroup tokens={desktop} />

--- a/src/tokens/newsGradientTokens.stories.svelte
+++ b/src/tokens/newsGradientTokens.stories.svelte
@@ -1,14 +1,17 @@
+<script context="module">
+  export const meta = {
+    title: 'Tokens/News/Gradients'
+  }
+</script>
 <script lang="ts">
   import { onMount } from 'svelte'
-  import { Meta, Story } from '@storybook/addon-svelte-csf'
+  import { Story } from '@storybook/addon-svelte-csf'
   import { gradient as allGradients } from '../../tokens/css/variables-news'
   import ColorTokenSwatchGroup from '../storyHelpers/ColorTokenSwatchGroup.svelte'
   import { scopedApplyLayer } from '../../.storybook/global.svelte'
 
   onMount(() => scopedApplyLayer("variables-news"))
 </script>
-
-<Meta title="Tokens/News/Gradients" />
 
 <Story name="All Gradients">
   <ColorTokenSwatchGroup tokens={allGradients} swatchSize={300} />

--- a/src/tokens/newtabFontTokens.stories.svelte
+++ b/src/tokens/newtabFontTokens.stories.svelte
@@ -1,14 +1,17 @@
+<script context="module">
+  export const meta = {
+    title: 'Tokens/New Tab/Fonts'
+  }
+</script>
 <script lang="ts">
   import { onMount } from 'svelte'
-  import { Meta, Story } from '@storybook/addon-svelte-csf'
+  import { Story } from '@storybook/addon-svelte-csf'
   import { font as allFonts } from '../../tokens/css/variables-newtab'
   import FontTokenSwatchGroup from '../storyHelpers/FontTokenSwatchGroup.svelte'
   import { scopedApplyLayer } from '../../.storybook/global.svelte'
 
   onMount(() => scopedApplyLayer("variables-newtab"))
 </script>
-
-<Meta title="Tokens/New Tab/Fonts" />
 
 <Story name="All Fonts">
   <FontTokenSwatchGroup tokens={allFonts} />

--- a/src/tokens/newtabGradientTokens.stories.svelte
+++ b/src/tokens/newtabGradientTokens.stories.svelte
@@ -1,14 +1,17 @@
+<script context="module">
+  export const meta = {
+    title: 'Tokens/New Tab/Gradients'
+  }
+</script>
 <script lang="ts">
   import { onMount } from 'svelte'
-  import { Meta, Story } from '@storybook/addon-svelte-csf'
+  import { Story } from '@storybook/addon-svelte-csf'
   import { gradient as allGradients } from '../../tokens/css/variables-newtab'
   import ColorTokenSwatchGroup from '../storyHelpers/ColorTokenSwatchGroup.svelte'
   import { scopedApplyLayer } from '../../.storybook/global.svelte'
 
   onMount(() => scopedApplyLayer("variables-newtab"))
 </script>
-
-<Meta title="Tokens/New Tab/Gradients" />
 
 <Story name="All Gradients">
   <ColorTokenSwatchGroup tokens={allGradients} swatchSize={300} />

--- a/src/tokens/searchFontTokens.stories.svelte
+++ b/src/tokens/searchFontTokens.stories.svelte
@@ -1,14 +1,17 @@
+<script context="module">
+  export const meta = {
+    title: 'Tokens/Search/Fonts'
+  }
+</script>
 <script lang="ts">
   import { onMount } from 'svelte'
-  import { Meta, Story } from '@storybook/addon-svelte-csf'
+  import { Story } from '@storybook/addon-svelte-csf'
   import { font as allFonts } from '../../tokens/css/variables-search'
   import FontTokenSwatchGroup from '../storyHelpers/FontTokenSwatchGroup.svelte'
   import { scopedApplyLayer } from '../../.storybook/global.svelte'
 
   onMount(() => scopedApplyLayer("variables-search"))
 </script>
-
-<Meta title="Tokens/Search/Fonts" />
 
 <Story name="All Fonts">
   <FontTokenSwatchGroup tokens={allFonts} />

--- a/src/tokens/searchGradientTokens.stories.svelte
+++ b/src/tokens/searchGradientTokens.stories.svelte
@@ -1,14 +1,17 @@
+<script context="module">
+  export const meta = {
+    title: 'Tokens/Search/Gradients'
+  }
+</script>
 <script lang="ts">
   import { onMount } from 'svelte'
-  import { Meta, Story } from '@storybook/addon-svelte-csf'
+  import { Story } from '@storybook/addon-svelte-csf'
   import { gradient as allGradients } from '../../tokens/css/variables-search'
   import ColorTokenSwatchGroup from '../storyHelpers/ColorTokenSwatchGroup.svelte'
   import { scopedApplyLayer } from '../../.storybook/global.svelte'
 
   onMount(() => scopedApplyLayer("variables-search"))
 </script>
-
-<Meta title="Tokens/Search/Gradients" />
 
 <Story name="All Gradients">
   <ColorTokenSwatchGroup tokens={allGradients} swatchSize={300} />

--- a/src/tokens/universalColorTokens.stories.svelte
+++ b/src/tokens/universalColorTokens.stories.svelte
@@ -1,5 +1,10 @@
+<script context="module">
+  export const meta = {
+    title: 'Tokens/Universal/Colors'
+  }
+</script>
 <script lang="ts">
-  import { Meta, Story } from '@storybook/addon-svelte-csf'
+  import { Story } from '@storybook/addon-svelte-csf'
   import { color as allColors } from '../../tokens/css/variables'
   import ColorTokenSwatchGroup from '../storyHelpers/ColorTokenSwatchGroup.svelte'
 
@@ -42,8 +47,6 @@
     black
   }
 </script>
-
-<Meta title="Tokens/Universal/Colors" />
 
 <Story name="All Colors">
   <ColorTokenSwatchGroup tokens={allColorsForDisplay} />

--- a/src/tokens/universalFontTokens.stories.svelte
+++ b/src/tokens/universalFontTokens.stories.svelte
@@ -1,12 +1,15 @@
+<script context="module">
+  export const meta = {
+    title: 'Tokens/Universal/Fonts'
+  }
+</script>
 <script lang="ts">
-  import { Meta, Story } from '@storybook/addon-svelte-csf'
+  import { Story } from '@storybook/addon-svelte-csf'
   import { font as allFonts } from '../../tokens/css/variables'
   import FontTokenSwatchGroup from '../storyHelpers/FontTokenSwatchGroup.svelte'
 
   const { monospace, ...sansMonospace } = allFonts
 </script>
-
-<Meta title="Tokens/Universal/Fonts" />
 
 <Story name="All Fonts">
   <FontTokenSwatchGroup tokens={sansMonospace} />

--- a/src/tokens/universalGradientTokens.stories.svelte
+++ b/src/tokens/universalGradientTokens.stories.svelte
@@ -1,10 +1,13 @@
+<script context="module">
+  export const meta = {
+    title: 'Tokens/Universal/Gradients'
+  }
+</script>
 <script lang="ts">
-  import { Meta, Story } from '@storybook/addon-svelte-csf'
+  import { Story } from '@storybook/addon-svelte-csf'
   import { gradient as allGradients } from '../../tokens/css/variables'
   import ColorTokenSwatchGroup from '../storyHelpers/ColorTokenSwatchGroup.svelte'
 </script>
-
-<Meta title="Tokens/Universal/Gradients" />
 
 <Story name="All Gradients">
   <ColorTokenSwatchGroup tokens={allGradients} swatchSize={300} />


### PR DESCRIPTION
Storybook now expects an exported meta object at the module level, rather than a <Meta /> element. This change modifies the stories to adhere to the new pattern. In a couple cases the `name` attribute of a `<Story />` element needed to be changed to avoid attempted reuse of an identifier within the same context.