### PR TITLE
[Dialog]: ensure dialog doesn't unnecessarily fill screen height

### DIFF
--- a/src/components/dialog/dialog.svelte
+++ b/src/components/dialog/dialog.svelte
@@ -135,6 +135,7 @@
     margin: auto;
     border: none;
     display: grid;
+    align-content: center;
 
     width: calc(100% - var(--leo-spacing-m) * 2);
     max-width: var(--leo-dialog-width, 374px);


### PR DESCRIPTION
For some reason, the dialog viewed on ipads tries to take up the entire screen.

| before | after |
| -- | -- |
| ![Simulator Screenshot - iPad (10th generation) - 2025-02-21 at 16 22 16](https://github.com/user-attachments/assets/0854cd60-3eb1-4bfa-984a-6c0eab1fe076) | ![Simulator Screenshot - iPad (10th generation) - 2025-02-21 at 16 22 35](https://github.com/user-attachments/assets/d77b92a3-f913-458e-8ba0-bbe0a29663c8) |