### PR TITLE
[Dialog]: Remove outline

### DIFF
--- a/src/components/dialog/dialog.svelte
+++ b/src/components/dialog/dialog.svelte
@@ -141,6 +141,7 @@
     max-width: var(--leo-dialog-width, 374px);
 
     border-radius: var(--border-radius);
+    outline: none;
 
     color: var(--color);
 


### PR DESCRIPTION
Sometimes this outline shows up when the dialog is triggered programmatically in webcomponents land.