### PR TITLE
[Dialog]: Don't fire close event when `display: none`

### DIFF
--- a/src/components/dialog/dialog.svelte
+++ b/src/components/dialog/dialog.svelte
@@ -101,7 +101,7 @@
 
 <svelte:window
   on:click|capture={(e) => {
-    if (!dialog || !isOpen || !backdropClickCloses) return
+    if (!dialog || !isOpen || !backdropClickCloses || !dialog.checkVisibility()) return
 
     const rect = dialog.getBoundingClientRect()
     const clickedOutside =


### PR DESCRIPTION
I have a situation in `brave-core` where I want to conditionally render some content in a dialog. I need to control this solely via CSS.

It works pretty well, except that the close event is fired on the dialog, even when it is `display: none`