### PR TITLE
[Checkbox]: Make control fill web component

### DIFF
--- a/src/components/checkbox/checkbox.svelte
+++ b/src/components/checkbox/checkbox.svelte
@@ -47,6 +47,10 @@
     display: inline-block;
   }
 
+  :host .leo-checkbox {
+    width: 100%;
+  }
+
   .leo-checkbox {
     --focus-border-radius: var(--leo-checkbox-focus-border-radius, 2px);
     --label-gap: var(--leo-checkbox-label-gap, var(--leo-spacing-m));


### PR DESCRIPTION
This fixes this kind of overflow when the Checkbox is used inside a WebComponent:
![image](https://github.com/user-attachments/assets/b896d681-1484-4612-9e3b-177cd49a76ea)

After the fix:
![image](https://github.com/user-attachments/assets/11eb436c-e35f-4c71-b372-4325a64443a7)


(we already do this with the RadioButton)