### PR TITLE
[Components]: Change instances of ':global selector' to ':global(selector)'

### DIFF
--- a/src/components/alert/alert.svelte
+++ b/src/components/alert/alert.svelte
@@ -63,7 +63,7 @@
     display: block;
   }
 
-  :global .leo-alert .actions > *,
+  :global(.leo-alert .actions > *),
   .leo-alert .actions ::slotted(*) {
     display: flex;
     flex-direction: row;

--- a/src/components/dialog/dialog.svelte
+++ b/src/components/dialog/dialog.svelte
@@ -239,8 +239,8 @@
     *
     * The :global selector doesn't seem to be able to handle nesting, so we have
     * two separate selectors for mobile & non-mobile layouts */
-  :global .leo-dialog .actions ::slotted(*),
-  :global .leo-dialog .actions [slot='actions']:not(:empty) {
+  :global(.leo-dialog .actions ::slotted(*)),
+  :global(.leo-dialog .actions [slot='actions']:not(:empty)) {
     display: flex;
     gap: var(--leo-spacing-xl);
     flex-direction: column;
@@ -249,8 +249,8 @@
   }
 
   @media (orientation: portrait) {
-    :global .leo-dialog .actions ::slotted(*),
-    :global .leo-dialog .actions div[slot='actions'] {
+    :global(.leo-dialog .actions ::slotted(*)),
+    :global(.leo-dialog .actions div[slot='actions']) {
       flex-direction: column;
       align-items: stretch;
     }
@@ -270,8 +270,8 @@
       max-width: var(--leo-dialog-width, 500px);
     }
 
-    :global .leo-dialog .actions ::slotted(*),
-    :global .leo-dialog [slot='actions']:not(:empty) {
+    :global(.leo-dialog .actions ::slotted(*)),
+    :global(.leo-dialog [slot='actions']:not(:empty)) {
       flex-direction: row;
       align-items: center;
       justify-content: end;

--- a/src/components/icon/icon.svelte
+++ b/src/components/icon/icon.svelte
@@ -65,7 +65,7 @@
     flex-shrink: 0;
 
     & .icon,
-    :global svg {
+    :global(svg) {
       width: 100%;
       height: 100%;
     }

--- a/src/components/menu/menu.svelte
+++ b/src/components/menu/menu.svelte
@@ -239,8 +239,8 @@
   }
 
   /* custom items can fit in by making optional use of these variables */
-  :global .leo-menu-popup ::slotted(*),
-  :global .leo-menu-popup > * {
+  :global(.leo-menu-popup ::slotted(*)),
+  :global(.leo-menu-popup > *) {
     --leo-menu-item-margin: var(--leo-spacing-s);
     --leo-menu-item-padding:  var(--leo-spacing-m) var(--leo-spacing-xl);
     --leo-menu-item-border-radius: var(--leo-spacing-s);
@@ -252,10 +252,10 @@
    * Each pseudo element has two sets of selectors: One for when it's inside a Svelte component, and one for
    * inside a web component. This could be simplified if leo-menu-item becomes its own Component.
    */
-  :global :where(.leo-menu-popup) ::slotted(leo-menu-item),
-  :global :where(.leo-menu-popup) ::slotted(leo-option),
-  :global :where(.leo-menu-popup) > leo-menu-item,
-  :global :where(.leo-menu-popup) > leo-option {
+  :global(:where(.leo-menu-popup) ::slotted(leo-menu-item)),
+  :global(:where(.leo-menu-popup) ::slotted(leo-option)),
+  :global(:where(.leo-menu-popup) > leo-menu-item),
+  :global(:where(.leo-menu-popup) > leo-option) {
     all: unset;
     cursor: pointer;
     margin: var(--leo-menu-item-margin);
@@ -264,29 +264,29 @@
     display: revert;
   }
 
-  :global :where(.leo-menu-popup) ::slotted(leo-menu-item:hover),
-  :global :where(.leo-menu-popup) ::slotted(leo-option:hover),
-  :global :where(.leo-menu-popup) > leo-menu-item:hover,
-  :global :where(.leo-menu-popup) > leo-option:hover {
+  :global(:where(.leo-menu-popup) ::slotted(leo-menu-item:hover)),
+  :global(:where(.leo-menu-popup) ::slotted(leo-option:hover)),
+  :global(:where(.leo-menu-popup) > leo-menu-item:hover),
+  :global(:where(.leo-menu-popup) > leo-option:hover) {
     background: var(--leo-color-container-highlight);
   }
 
-  :global :where(.leo-menu-popup) ::slotted(leo-option[aria-selected]),
-  :global :where(.leo-menu-popup) ::slotted(leo-menu-item[aria-selected]),
-  :global :where(.leo-menu-popup) ::slotted(leo-option:active),
-  :global :where(.leo-menu-popup) ::slotted(leo-menu-item:active),
-  :global :where(.leo-menu-popup) > leo-option[aria-selected],
-  :global :where(.leo-menu-popup) > leo-menu-item[aria-selected],
-  :global :where(.leo-menu-popup) > leo-option:active,
-  :global :where(.leo-menu-popup) > leo-menu-item:active {
+  :global(:where(.leo-menu-popup) ::slotted(leo-option[aria-selected])),
+  :global(:where(.leo-menu-popup) ::slotted(leo-menu-item[aria-selected])),
+  :global(:where(.leo-menu-popup) ::slotted(leo-option:active)),
+  :global(:where(.leo-menu-popup) ::slotted(leo-menu-item:active)),
+  :global(:where(.leo-menu-popup) > leo-option[aria-selected]),
+  :global(:where(.leo-menu-popup) > leo-menu-item[aria-selected]),
+  :global(:where(.leo-menu-popup) > leo-option:active),
+  :global(:where(.leo-menu-popup) > leo-menu-item:active) {
     background: var(--leo-color-container-interactive);
     color: var(--leo-color-text-interactive);
   }
 
-  :global :where(.leo-menu-popup) ::slotted(leo-option:focus-visible),
-  :global :where(.leo-menu-popup) ::slotted(leo-menu-item:focus-visible),
-  :global :where(.leo-menu-popup) > leo-option:focus-visible,
-  :global :where(.leo-menu-popup) > leo-menu-item:focus-visible {
+  :global(:where(.leo-menu-popup) ::slotted(leo-option:focus-visible)),
+  :global(:where(.leo-menu-popup) ::slotted(leo-menu-item:focus-visible)),
+  :global(:where(.leo-menu-popup) > leo-option:focus-visible),
+  :global(:where(.leo-menu-popup) > leo-menu-item:focus-visible) {
     box-shadow:
       0px 0px 0px 1.5px rgba(255, 255, 255, 0.5),
       0px 0px 4px 2px #423eee;

--- a/src/components/segmentedControl/segmentedControl.svelte
+++ b/src/components/segmentedControl/segmentedControl.svelte
@@ -169,35 +169,35 @@
         left 0.4s cubic-bezier(0.22, 1, 0.36, 1);
     }
 
-    :where(&) > :global .leo-control-item,
-    :where(&) > :global ::slotted(leo-controlitem) {
+    :where(&) > :global(.leo-control-item),
+    :where(&) > :global(::slotted(leo-controlitem)) {
       --leo-control-item-icon-color: var(--leo-color-icon-default);
       --leo-control-item-color: var(--leo-color-text-secondary);
       --leo-control-item-background: transparent;
       --leo-control-item-radius: calc(var(--radius) - var(--control-padding));
     }
 
-    :where(&:not(.transitioning)) > :global .leo-control-item:hover,
-    :where(&:not(.transitioning)) > :global ::slotted(leo-controlitem:hover) {
+    :where(&:not(.transitioning)) > :global(.leo-control-item:hover),
+    :where(&:not(.transitioning)) > :global(::slotted(leo-controlitem:hover)) {
       --leo-control-item-background: var(--leo-color-container-highlight);
       --leo-control-item-color: var(--leo-color-text-primary);
     }
 
-    :where(&) > :global .leo-control-item:focus-visible,
-    :where(&) > :global ::slotted(leo-controlitem:focus-visible) {
+    :where(&) > :global(.leo-control-item:focus-visible),
+    :where(&) > :global(::slotted(leo-controlitem:focus-visible)) {
       --leo-control-item-shadow: var(--leo-effect-focus-state);
     }
 
-    :where(&) > :global .leo-control-item[aria-selected],
-    :where(&) > :global ::slotted(leo-controlitem[aria-selected]) {
+    :where(&) > :global(.leo-control-item[aria-selected]),
+    :where(&) > :global(::slotted(leo-controlitem[aria-selected])) {
       --leo-control-item-color: var(--leo-color-text-interactive);
       --leo-icon-color: var(--leo-color-icon-interactive);
     }
 
-    :where(&.transitioning) > :global .leo-control-item[aria-selected],
-    :where(&.transitioning) > :global ::slotted(leo-controlitem[aria-selected]),
-    :where(&) > :global .leo-control-item[aria-selected]:hover,
-    :where(&) > :global ::slotted(leo-controlitem[aria-selected]:hover) {
+    :where(&.transitioning) > :global(.leo-control-item[aria-selected]),
+    :where(&.transitioning) > :global(::slotted(leo-controlitem[aria-selected])),
+    :where(&) > :global(.leo-control-item[aria-selected]:hover),
+    :where(&) > :global(::slotted(leo-controlitem[aria-selected]:hover)) {
       --leo-control-item-icon-color: currentColor;
       --leo-control-item-background: var(--leo-color-container-background);
     }


### PR DESCRIPTION
Using :global without parentheses around the targeted selector seems to
be undocumented, and results in an error in some environments. See for
example https://svelte.dev/playground/568dfa21589d4854a86243373526127c?version=4.2.19
