### PR TITLE
[types]: Fix generated WebComponent types

### DIFF
--- a/src/scripts/gen-types.js
+++ b/src/scripts/gen-types.js
@@ -11,7 +11,7 @@ const genTypes = async (options = {}) => {
   await svelte2tsx.emitDts({
     libRoot: basePath,
     declarationDir: outputDir,
-    svelteShimsPath: path.resolve('svelte2tsx/svelte-shims.d.ts')
+    svelteShimsPath: path.resolve('node_modules/svelte2tsx/svelte-shims.d.ts')
   })
 }
 


### PR DESCRIPTION
`path.resolve` is relative to the package root, while `require.resolve` is relative to `node_modules` 