### PR TITLE
[types]: Add test for gen-types

### DIFF
--- a/tests/gen-types.test.ts
+++ b/tests/gen-types.test.ts
@@ -1,0 +1,25 @@
+const { readFileSync } = require('fs')
+describe('gen-types', () => {
+  it('generated types smoketest', () => {
+    const expectProps = {
+      'checkbox': ['checked: boolean', 'isDisabled?: boolean', 'size?: Sizes'],
+      'button': [
+        'kind?: Props.ButtonKind',
+        'size?: Props.ButtonSize',
+        'fab?: boolean',
+        'loading: {}'
+      ],
+      'icon': ['name?: IconName', 'forceColor?: boolean', 'title?: string']
+    }
+
+    for (const [component, props] of Object.entries(expectProps)) {
+      const generatedTypes = readFileSync(
+        `./types/src/components/${component}/${component}.svelte.d.ts`,
+        'utf-8'
+      )
+      for (const prop of props) {
+        expect(generatedTypes).toContain(prop)
+      }
+    }
+  })
+})


### PR DESCRIPTION
This adds a smoke test that types are being generated correctly. It's not part of #1065 because none of the jest tests are passing at the moment (and don't seem to run on CI) and that needs to land urgently

Blocked on https://github.com/brave/leo/pull/1067