### PR TITLE
[Dialog]: Fix input field tab order

### DIFF
--- a/src/components/dialog/dialog.stories.svelte
+++ b/src/components/dialog/dialog.stories.svelte
@@ -1,5 +1,6 @@
 <script context="module">
   import Dialog from './dialog.svelte'
+  import Input from '../input/input.svelte'
 
   export const meta = {
     title: 'Components/Dialog',
@@ -84,6 +85,7 @@
       </div>
     </div>
     <div slot="actions">
+      <Input placeholder="This is an input field" />
       <Button kind="outline">Secondary</Button>
       <Button kind="filled">Primary</Button>
     </div>
@@ -144,6 +146,8 @@
 </Story>
 
 <Story name="Default" />
+
+<Story name="Show Close" args={{showClose: true}} />
 
 <style>
   .alert-container {

--- a/src/components/input/input.svelte
+++ b/src/components/input/input.svelte
@@ -138,7 +138,9 @@
   let tabindex : number;
   
   onMount(() => {
-    tabindex = input.getRootNode() === document ? $$restProps.tabindex : 1;
+    const inputRootNode = input.getRootNode() as ShadowRoot;
+
+    tabindex = inputRootNode.host?.tagName === 'LEO-INPUT' ? 1 : $$restProps.tabindex;
   });
 
 </script>

--- a/src/components/input/input.svelte
+++ b/src/components/input/input.svelte
@@ -14,6 +14,7 @@
   import Button from '../button/button.svelte'
   import FormItem, { type Mode, type Size } from '../formItem/formItem.svelte'
   import Icon from '../icon/icon.svelte'
+  import  { onMount } from 'svelte'
 
   type OverrideProps = 'type' | 'value' | 'size' | 'class' | `on:${string}`
   type LeoInputTypeAttribute =
@@ -133,6 +134,13 @@
     value = e.currentTarget['value']
     hasErrorsInternal = (required && !value) || !input?.checkValidity()
   }
+
+  let tabindex : number;
+  
+  onMount(() => {
+    tabindex = input.getRootNode() === document ? $$restProps.tabindex : 1;
+  });
+
 </script>
 
 <FormItem
@@ -152,7 +160,7 @@
       {type}
       {value}
       {placeholder}
-      tabindex={1}
+      {tabindex}
       bind:this={input}
       on:input={handleInput}
       on:change={forward(onChange)}


### PR DESCRIPTION
# What?

Related tasks: https://github.com/brave/leo/issues/997

On the dialog, the tab order is incorrect when you have the close button turned on. In the case of the issue reported above (https://github.com/brave/leo/issues/997) the input field has the attribute `tabindex=1`,  and ~~adding the same `tabindex=1` to the close button keeps the order correct~~.

The bug is actually a side effect of adding `tabindex=1` to the Input field so tabbing works properly in a shadowroot for the input field. The fix here is to conditionally add tab index when the root node for the Input field is not the document.

## Details
- Conditionally adds `tabindex=1` attribute to the Input component when the root note is not the document
- Adds a storybook story for `Show Close`
- Adds an input field to the default Dialog component in storybook

## Screenshots
### Before

https://github.com/user-attachments/assets/66d74a08-eca8-479a-b17c-d5a6be3965bd

### After

https://github.com/user-attachments/assets/3ce82aa4-5538-4a8c-a139-cbd41a032c60

### Input Field in the Shadow DOM
![image](https://github.com/user-attachments/assets/5fe16ff5-c80f-429d-9448-28ddb742ee02)

