### PR TITLE
[renovate]: Add renovate PRs to svelte4-lts branch

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,7 @@
   "labels": ["dependencies", "renovate"],
   "prConcurrentLimit": 4,
   "rangeStrategy": "pin",
+  "baseBranches": ["main", "svelte4-lts"],
   "packageRules": [
     {
       "matchDepTypes": ["peerDependencies"],


### PR DESCRIPTION
@benjaminknox is creating a branch with Svelte 5. Once that merges its going to be a while upgrading all our projects to Svelte 5 so they can consume the latest version of Nala.

https://github.com/brave/leo/pull/1078

Once it lands, we're going to want dependency updates to keep landing in our svelte4 branch.