### PR TITLE
[ButtonMenu]: Make placement configurable

### DIFF
--- a/src/components/buttonMenu/buttonMenu.stories.svelte
+++ b/src/components/buttonMenu/buttonMenu.stories.svelte
@@ -96,7 +96,7 @@
       name="anchor-content"
       explanation="A custom icon inside of anchor button"
     >
-      <ButtonMenu>
+      <ButtonMenu {...args}>
         <div slot="anchor-content">
           <Icon name="more-horizontal" />
         </div>

--- a/src/components/buttonMenu/buttonMenu.svelte
+++ b/src/components/buttonMenu/buttonMenu.svelte
@@ -15,12 +15,13 @@
 
 <script lang="ts">
   import Menu, { type CloseEvent } from '../menu/menu.svelte'
-  import type { Strategy } from '@floating-ui/dom'
+  import type { Strategy, Placement } from '@floating-ui/dom'
 
   export let isOpen: boolean | undefined = undefined
   export let onClose: CloseEvent = undefined
   export let onChange: (e: { isOpen: boolean }) => void = undefined
   export let positionStrategy: Strategy = 'absolute'
+  export let placement: Placement = 'bottom-start'
 
   let anchor: HTMLElement
 
@@ -56,7 +57,8 @@
     <slot name="anchor-content"/>
   </div>
   {#if isOpenInternal}
-    <Menu 
+    <Menu
+      {placement}
       {positionStrategy} 
       isOpen={isOpenInternal} 
       target={anchor} 

--- a/src/components/menu/menu.svelte
+++ b/src/components/menu/menu.svelte
@@ -34,12 +34,13 @@
 <script lang="ts">
   import clickOutside from '../../svelteDirectives/clickOutside'
   import Floating from '../floating/floating.svelte'
-  import { size as sizeMiddleware, type Strategy } from '@floating-ui/dom'
+  import { size as sizeMiddleware, type Placement, type Strategy } from '@floating-ui/dom'
 
   export let isOpen = false
   export let target: HTMLElement | undefined = undefined
   export let currentValue: string | undefined = undefined
   export let positionStrategy: Strategy = 'absolute'
+  export let placement: Placement = 'bottom-start'
   export let onClose: CloseEvent =
     undefined
   export let onSelectItem: (detail: SelectItemEventDetail) => void = undefined
@@ -183,7 +184,7 @@
   {#if isOpen}
     <Floating
       {target}
-      placement="bottom-start"
+      {placement}
       autoUpdate
       middleware={floatingMiddleware}
       {positionStrategy}


### PR DESCRIPTION
In brave-core we have a few bits of UI where the Menu should anchor to the top! At the moment this is most coincidentally working because we're showing the menus at the bottom of the screen so they get flipped to show above (because there isn't enough space).

This exposes the properties.