### PR TITLE
[icons]: Hopefully fix update-icons action

### DIFF
--- a/.github/workflows/update-icons.yml
+++ b/.github/workflows/update-icons.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          npm ci
+          npm ci --ignore-scripts
 
       - name: Update icons
         run: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "babel-loader": "9.2.1",
         "css-loader": "6.11.0",
         "css-tree": "2.3.1",
-        "figma-api-exporter": "github:brave/figma-api-exporter#08ea66f0794fcb3fa0240692d9016a562b4fbcef",
+        "figma-api-exporter": "github:brave/figma-api-exporter#edd8385c12bd9c7bd26fa48b79ca67c3a5b80cce",
         "jsdom": "21.1.2",
         "lodash.camelcase": "4.3.0",
         "lodash.merge": "4.6.2",
@@ -6239,8 +6239,8 @@
     },
     "node_modules/figma-api-exporter": {
       "version": "0.0.2",
-      "resolved": "git+ssh://git@github.com/brave/figma-api-exporter.git#08ea66f0794fcb3fa0240692d9016a562b4fbcef",
-      "integrity": "sha512-UW8x20OaKtX+CYXSJD8akNl0uiqMSRZnUyB0JPLsaBFKv1Dfnumgejk8lMWGooKMTBUrVp/myYCBDTzS91vvmg==",
+      "resolved": "git+ssh://git@github.com/brave/figma-api-exporter.git#edd8385c12bd9c7bd26fa48b79ca67c3a5b80cce",
+      "integrity": "sha512-HPPwhDhL+5W8ENSp2Pg1eGwhavjnnC9pv7fsapc7+xwMPlgX95mPyL8SeLTsyppy+ThE/aRTD+NPNuOhBO+ucg==",
       "dev": true
     },
     "node_modules/file-entry-cache": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "babel-loader": "9.2.1",
     "css-loader": "6.11.0",
     "css-tree": "2.3.1",
-    "figma-api-exporter": "github:brave/figma-api-exporter#08ea66f0794fcb3fa0240692d9016a562b4fbcef",
+    "figma-api-exporter": "github:brave/figma-api-exporter#edd8385c12bd9c7bd26fa48b79ca67c3a5b80cce",
     "jsdom": "21.1.2",
     "lodash.camelcase": "4.3.0",
     "lodash.merge": "4.6.2",


### PR DESCRIPTION
Bumps to a version of figma-api-exporter using esmodules

Failing workflow from before this PR:
https://github.com/brave/leo/actions/runs/15960222266

Passing workflow (using this branch):
https://github.com/brave/leo/actions/runs/15960441050