### PR TITLE
adjust dropdown gap between parent and floating element

### DIFF
--- a/src/components/floating/floating.svelte
+++ b/src/components/floating/floating.svelte
@@ -30,11 +30,11 @@
 
   /** The shift padding to apply to the floating element. See
    * https://floating-ui.com/docs/shift for more details. */
-  export let shift: number | undefined = 8
+  export let shift: number | undefined = 2
 
   /** The gap between the target and the floating element:
    * https://floating-ui.com/docs/offset */
-  export let offset: number = 8
+  export let offset: number = 2
 
   /** Additional middleware to apply. */
   export let middleware: Middleware[] = []


### PR DESCRIPTION
Adjusted the distance between the dropdown elements and the parent so they're closed together.


### Before:

<img width="314" alt="image" src="https://github.com/user-attachments/assets/38d7851d-da0b-4ed9-a1d8-8fc294720eb8" />



### Fix:
<img width="1023" alt="image" src="https://github.com/user-attachments/assets/9f6419a5-62b7-4b39-8382-eea7953be5ae" />
