### PR TITLE
[Fonts]: transform tailwind fonts into system-ui fonts

### DIFF
--- a/src/tokens/transformation/common/fontHelper.ts
+++ b/src/tokens/transformation/common/fontHelper.ts
@@ -1,0 +1,18 @@
+export const SYSTEM_UI_STACK =
+  "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+
+export const isSFPro = (name: string) =>
+  /^(SF Pro|SFPro|San Francisco|SF Pro Display|SF Pro Text|SF Pro Rounded)$/i.test(
+    name
+  )
+
+export const fontFamily = (
+  { fontFamily },
+  { fontFamilies }: { fontFamilies?: { [key: string]: string } } = {}
+) => {
+  const resolved =
+    fontFamilies && fontFamilies[fontFamily]
+      ? fontFamilies[fontFamily]
+      : fontFamily
+  return isSFPro(resolved) ? SYSTEM_UI_STACK : resolved
+}

--- a/src/tokens/transformation/common/fontHelper.ts
+++ b/src/tokens/transformation/common/fontHelper.ts
@@ -10,9 +10,6 @@ export const fontFamily = (
   { fontFamily },
   { fontFamilies }: { fontFamilies?: { [key: string]: string } } = {}
 ) => {
-  const resolved =
-    fontFamilies && fontFamilies[fontFamily]
-      ? fontFamilies[fontFamily]
-      : fontFamily
+  const resolved = fontFamilies?.[fontFamily] ?? fontFamily
   return isSFPro(resolved) ? SYSTEM_UI_STACK : resolved
 }

--- a/src/tokens/transformation/common/fontHelper.ts
+++ b/src/tokens/transformation/common/fontHelper.ts
@@ -1,7 +1,7 @@
-export const SYSTEM_UI_STACK =
+const SYSTEM_UI_STACK =
   "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
 
-export const isSFPro = (name: string) =>
+const isSFPro = (name: string) =>
   /^(SF Pro|SFPro|San Francisco|SF Pro Display|SF Pro Text|SF Pro Rounded)$/i.test(
     name
   )

--- a/src/tokens/transformation/tailwind/twFont.ts
+++ b/src/tokens/transformation/tailwind/twFont.ts
@@ -1,17 +1,18 @@
 import { Transform } from 'style-dictionary'
+import { fontFamily } from '../common/fontHelper'
 
 export default {
   type: 'value',
   matcher(token) {
     return token.type === 'custom-fontStyle'
   },
-  transformer({ value: font }) {
+  transformer({ value: font }, platform) {
     return {
       fontSize: `${font.fontSize}px`,
       lineHeight: `${font.lineHeight}px`,
       letterSpacing: `${font.letterSpacing}px`,
       fontWeight: font.fontWeight,
-      fontFamily: font.fontFamily
+      fontFamily: fontFamily(font, platform?.options as any)
     }
   }
 } as Transform

--- a/src/tokens/transformation/web/webFont.ts
+++ b/src/tokens/transformation/web/webFont.ts
@@ -1,26 +1,8 @@
 import { Transform } from 'style-dictionary'
+import { fontFamily } from '../common/fontHelper'
 
 const notDefault = (value, defaultValue) =>
   value !== defaultValue ? value : ''
-
-const SYSTEM_UI_STACK =
-  "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
-
-const isSFPro = (name: string) =>
-  /^(SF Pro|SFPro|San Francisco|SF Pro Display|SF Pro Text|SF Pro Rounded)$/i.test(
-    name
-  )
-
-const fontFamily = (
-  { fontFamily },
-  { fontFamilies }: { fontFamilies?: { [key: string]: string } } = {}
-) => {
-  const resolved =
-    fontFamilies && fontFamilies[fontFamily]
-      ? fontFamilies[fontFamily]
-      : fontFamily
-  return isSFPro(resolved) ? SYSTEM_UI_STACK : resolved
-}
 
 export default {
   type: 'value',


### PR DESCRIPTION
This PR moves the changes from https://github.com/brave/leo/pull/1158 to a helper module, and applies them to `twFont.ts` as well.