### PR TITLE
[FormItem]: Add 'inline' mode

### DIFF
--- a/src/components/dropdown/dropdown.stories.svelte
+++ b/src/components/dropdown/dropdown.stories.svelte
@@ -137,6 +137,8 @@
 
 <Story name="Default" />
 
+<Story name="Inline" args={{ mode: 'inline' }} />
+
 <Story name="Left Icon" let:args>
   <div class="container">
     <Dropdown {...args}>

--- a/src/components/formItem/formItem.svelte
+++ b/src/components/formItem/formItem.svelte
@@ -2,7 +2,7 @@
   export let sizes = ['small', 'normal', 'large'] as const
   export type Size = (typeof sizes)[number]
 
-  export let modes = ['filled', 'outline'] as const
+  export let modes = ['filled', 'outline', 'inline'] as const
   export type Mode = (typeof modes)[number]
 
   export let cssProperties: {
@@ -85,7 +85,8 @@
   class:isSmall={size === 'small'}
   class:isLarge={size === 'large'}
   class:isFilled={mode === 'filled'}
-  class:isOutline={mode !== 'filled'}
+  class:isOutline={mode === 'outline'}
+  class:isInline={mode === 'inline'}
   class:isFocused={showFocusOutline}
   class:error
   aria-disabled={disabled}
@@ -246,6 +247,15 @@
         color-mix(in srgb, var(--primary), var(--foreground) 20%)
       );
     }
+  }
+
+  .leo-control.isInline {
+    --padding: none;
+    --border-color: transparent;
+    --border-color-hover: transparent;
+    --shadow-hover: none;
+
+    display: inline-flex;
   }
 
   .leo-control.error {

--- a/src/components/formItem/formItem.svelte
+++ b/src/components/formItem/formItem.svelte
@@ -100,7 +100,9 @@
       <div class="extra-content">
         <slot name="left-icon" />
       </div>
-      <slot />
+      <div class="content">
+        <slot />
+      </div>
       <div class="extra-content">
         <slot name="right-icon" />
       </div>
@@ -116,7 +118,7 @@
     --primary: var(--leo-control-color, var(--base));
 
     --radius: var(--leo-control-radius, var(--leo-radius-m));
-    --padding: var(--leo-control-padding, 10px 7px);
+    --padding: var(--leo-control-padding, 11px var(--leo-spacing-m));
     --font: var(--leo-control-font, var(--leo-font-default-regular));
     --leo-icon-size: var(--leo-control-icon-size, 20px);
     --leo-icon-color: var(
@@ -161,6 +163,15 @@
     transition:
       color 0.2s ease-in-out;
 
+    .content {
+      padding: 0 var(--leo-spacing-s);
+      margin-inline-end: auto;
+    }
+
+    .extra-content:empty {
+      display: none;
+    }
+
     &:not([aria-disabled='true']) {
       & .container:hover {
         color: var(--color-hover);
@@ -192,13 +203,13 @@
   .leo-control.isSmall {
     --leo-icon-size: 16px;
     --font: var(--leo-control-font, var(--leo-font-small-regular));
-    --padding: var(--leo-control-padding, 7px);
+    --padding: var(--leo-control-padding, var(--leo-spacing-m));
     --gap: var(--leo-control-label-gap, 2px);
   }
 
   .leo-control.isLarge {
     --leo-icon-size: 22px;
-    --padding: var(--leo-control-padding, 14px 11px);
+    --padding: var(--leo-control-padding, 14px var(--leo-spacing-l));
     --gap: var(--leo-control-label-gap, 12px);
   }
 

--- a/src/components/input/input.stories.svelte
+++ b/src/components/input/input.stories.svelte
@@ -55,6 +55,8 @@
 
 <Story name="Default" />
 
+<Story name="Inline" args={{ mode: 'inline' }} />
+
 <Story name="Character Count" let:args>
   <Input {...args} bind:value={characterCountValue}>
     {args.label}


### PR DESCRIPTION
- **[FormItem: Fix spacing**
- **[FormItem]: Add 'inline' mode**

The immediate use for this is the language switcher for account.brave.com.

<img width="1223" height="616" alt="SCR-20250813-osfl" src="https://github.com/user-attachments/assets/10af88f9-17b0-4554-ab70-4a8ffdb1060b" />
