### PR TITLE
[FormItem]: Rename 'inline' mode to 'plain'

### DIFF
--- a/src/components/dropdown/dropdown.stories.svelte
+++ b/src/components/dropdown/dropdown.stories.svelte
@@ -138,16 +138,19 @@
 
 <Story name="Default" />
 
-<Story name="Inline" let:args>
+<Story name="Plain" let:args>
   <Link>Footer link</Link>
   <Link>Footer link</Link>
-  <Dropdown value={undefined} {...args} mode="inline">
-    <leo-option value="one">
-      <div>One</div>
-    </leo-option>
-    <leo-option value="two">Two</leo-option>
-    <leo-option>Three</leo-option>
-  </Dropdown>
+  <div style="display: inline-block; vertical-align: middle;">
+    <Dropdown value={undefined} {...args} mode="plain">
+      <Icon name="country-us" slot="left-icon" />
+      <leo-option value="one">
+        <div>One</div>
+      </leo-option>
+      <leo-option value="two">Two</leo-option>
+      <leo-option>Three</leo-option>
+    </Dropdown>
+  </div>
   <Link>Footer link</Link>
   <Link>Footer link</Link>
   <Link>Footer link</Link>

--- a/src/components/dropdown/dropdown.svelte
+++ b/src/components/dropdown/dropdown.svelte
@@ -44,43 +44,41 @@
   }
 </script>
 
-<div class="leo-dropdown" class:isInline={mode === 'inline'}>
-  <div>
-    <FormItem
-      bind:disabled
-      bind:required
-      bind:size
-      bind:controlElement={dropdown}
-      renderLabel={$$slots.default}
-      {mode}
-      showFocusOutline={isOpen}
-      error={showErrors && $$slots.errors}
+<div class="leo-dropdown">
+  <FormItem
+    bind:disabled
+    bind:required
+    bind:size
+    bind:controlElement={dropdown}
+    renderLabel={$$slots.default}
+    {mode}
+    showFocusOutline={isOpen}
+    error={showErrors && $$slots.errors}
+  >
+    <slot name="label" slot="label" />
+    <slot name="left-icon" slot="left-icon" />
+    <button
+      bind:this={button}
+      class="click-target"
+      {disabled}
+      on:click|stopPropagation={onClick}
     >
-      <slot name="label" slot="label" />
-      <slot name="left-icon" slot="left-icon" />
-      <button
-        bind:this={button}
-        class="click-target"
-        {disabled}
-        on:click|stopPropagation={onClick}
-      >
-        {#if value !== undefined}
-          <slot name="value" {value}>
-            <span class="value">{value}</span>
-          </slot>
-        {:else}
-          <slot name="placeholder">
-            <span class="placeholder">{placeholder}</span>
-          </slot>
-        {/if}
-      </button>
-      <slot name="right-icon" slot="right-icon">
-        <div class="indicator" class:open={isOpen}>
-          <Icon name="arrow-small-down" />
-        </div>
-      </slot>
-    </FormItem>
-  </div>
+      {#if value !== undefined}
+        <slot name="value" {value}>
+          <span class="value">{value}</span>
+        </slot>
+      {:else}
+        <slot name="placeholder">
+          <span class="placeholder">{placeholder}</span>
+        </slot>
+      {/if}
+    </button>
+    <slot name="right-icon" slot="right-icon">
+      <div class="indicator" class:open={isOpen}>
+        <Icon name="arrow-small-down" />
+      </div>
+    </slot>
+  </FormItem>
   <Menu
     target={dropdown}
     {positionStrategy}
@@ -115,10 +113,6 @@
   .leo-dropdown {
     cursor: pointer;
     -webkit-tap-highlight-color: transparent;
-
-    &.isInline {
-      display: inline-block;
-    }
 
     button {
       all: unset;

--- a/src/components/formItem/formItem.svelte
+++ b/src/components/formItem/formItem.svelte
@@ -2,7 +2,7 @@
   export let sizes = ['small', 'normal', 'large'] as const
   export type Size = (typeof sizes)[number]
 
-  export let modes = ['filled', 'outline', 'inline'] as const
+  export let modes = ['filled', 'outline', 'plain'] as const
   export type Mode = (typeof modes)[number]
 
   export let cssProperties: {
@@ -86,7 +86,7 @@
   class:isLarge={size === 'large'}
   class:isFilled={mode === 'filled'}
   class:isOutline={mode === 'outline'}
-  class:isInline={mode === 'inline'}
+  class:isPlain={mode === 'plain'}
   class:isFocused={showFocusOutline}
   class:error
   aria-disabled={disabled}
@@ -249,14 +249,19 @@
     }
   }
 
-  .leo-control.isInline {
+  .leo-control.isPlain {
     --background: transparent;
     --padding: none;
     --border-color: transparent;
     --border-color-hover: transparent;
     --shadow-hover: none;
-
-    display: inline-flex;
+    --font: inherit;
+    /**
+     * This magic number is meant to preserve the proportions
+     * between icon and text found the `normal` size:
+     * 20px ('normal' icon size) / 14px ('normal' font-size)
+     */
+    --leo-icon-size: 1.43em;
   }
 
   .leo-control.error {

--- a/src/components/input/input.stories.svelte
+++ b/src/components/input/input.stories.svelte
@@ -55,7 +55,7 @@
 
 <Story name="Default" />
 
-<Story name="Inline" args={{ mode: 'inline' }} />
+<Story name="Plain" args={{ mode: 'plain' }} />
 
 <Story name="Character Count" let:args>
   <Input {...args} bind:value={characterCountValue}>


### PR DESCRIPTION
Crucially, this means that the mode will no longer set the display property on FormItem and Dropdown to `inline-flex`, leaving this behavior up to the consumer to set.
