### PR TITLE
[Checkbox]: Make checkbox WebComponent work on iOS

### DIFF
--- a/examples/plain-html/index.html
+++ b/examples/plain-html/index.html
@@ -64,6 +64,7 @@
     import './leo/button.js'
     import './leo/link.js'
     import './leo/collapse.js'
+    import './leo/checkbox.js'
     import './leo/toggle.js'
     import './leo/progressRing.js'
     import './leo/progressBar.js'
@@ -201,6 +202,7 @@
     <leo-button href="https://brave.com">External link</leo-button>
     <leo-link href="https://brave.com">External link</leo-link>
     <leo-link id="link-button">Link Button</leo-link>
+    <leo-checkbox>Checkable!</leo-checkbox>
     <leo-collapse title="Handy dandy title">
       Some content which is hidden by default
     </leo-collapse>

--- a/src/components/checkbox/checkbox.svelte
+++ b/src/components/checkbox/checkbox.svelte
@@ -24,6 +24,7 @@
   class:small={size === 'small'}
   class:normal={size !== 'small'}
   class:disabled={isDisabled}
+  class:isChecked={checked}
 >
   <div class="check">
     <input
@@ -88,6 +89,23 @@
     &.disabled {
       cursor: not-allowed;
     }
+
+    // Note: We need both of these because WebKit doesn't support the :has
+    // selector inside a shadowRoot. The &:has(input:checked) is so we work in
+    // Chromium/Firefox when JS is disabled.
+    &.isChecked, &:has(input:checked) {
+     & .check {
+      color: var(--checked-color);
+
+      & .checked {
+        opacity: 1;
+      }
+
+      & .unchecked {
+        opacity: 0;
+      }
+     } 
+    }
   }
 
   .leo-checkbox.disabled {
@@ -132,18 +150,6 @@
 
     & .unchecked {
       opacity: 1;
-    }
-
-    &:has(input:checked) {
-      color: var(--checked-color);
-
-      & .checked {
-        opacity: 1;
-      }
-
-      & .unchecked {
-        opacity: 0;
-      }
     }
 
     &:has(input:focus-visible) {


### PR DESCRIPTION
This seems to be because WebKit doesn't like having a `:has` selector in a `shadowRoot`, which is why the Storybook was working