### PR TITLE
[ButtonMenu]: Expose Flip Prop

### DIFF
--- a/src/components/buttonMenu/buttonMenu.svelte
+++ b/src/components/buttonMenu/buttonMenu.svelte
@@ -22,6 +22,7 @@
   export let onChange: (e: { isOpen: boolean }) => void = undefined
   export let positionStrategy: Strategy = 'absolute'
   export let placement: Placement = 'bottom-start'
+  export let flip: boolean = true
 
   let anchor: HTMLElement
 
@@ -59,7 +60,8 @@
   {#if isOpenInternal}
     <Menu
       {placement}
-      {positionStrategy} 
+      {positionStrategy}
+      {flip}
       isOpen={isOpenInternal} 
       target={anchor} 
       onClose={close}

--- a/src/components/menu/menu.svelte
+++ b/src/components/menu/menu.svelte
@@ -41,6 +41,7 @@
   export let currentValue: string | undefined = undefined
   export let positionStrategy: Strategy = 'absolute'
   export let placement: Placement = 'bottom-start'
+  export let flip: boolean = true
   export let onClose: CloseEvent =
     undefined
   export let onSelectItem: (detail: SelectItemEventDetail) => void = undefined
@@ -185,6 +186,7 @@
     <Floating
       {target}
       {placement}
+      {flip}
       autoUpdate
       middleware={floatingMiddleware}
       {positionStrategy}


### PR DESCRIPTION
Exposes the `Flip` prop to the `ButtonMenu` to prevent unnecessary `flip`.

### Before

https://github.com/user-attachments/assets/b22e37d4-5b03-49dc-b964-4f8c95909461

### After

https://github.com/user-attachments/assets/0933358a-20f8-4723-a97f-3a42a163bac8
