### PR TITLE
update dialog to fix max height issues

### DIFF
--- a/src/components/dialog/dialog.svelte
+++ b/src/components/dialog/dialog.svelte
@@ -140,7 +140,6 @@
 
     width: calc(100% - var(--leo-spacing-m) * 2);
     max-width: var(--leo-dialog-width, 374px);
-    max-height: calc(100vh - var(--leo-spacing-m) * 2);
 
     border-radius: var(--border-radius);
     outline: none;


### PR DESCRIPTION
Issue to resolve https://github.com/brave/brave-browser/issues/48962

The max-height was creating problems on Android. Removing them fixes the issue

<img width="720" height="559" alt="image" src="https://github.com/user-attachments/assets/93d8ba26-c336-411b-b77b-720cc1115ece" />

<img width="3460" height="2684" alt="image" src="https://github.com/user-attachments/assets/4f2a135e-a77d-4bb3-9616-312873b3adb2" />
