### PR TITLE
[Menu]: Only consider non slotted elements when deciding if an item is first/last

### DIFF
--- a/src/components/menu/menu.svelte
+++ b/src/components/menu/menu.svelte
@@ -263,14 +263,14 @@
     --leo-menu-item-border-radius: var(--leo-spacing-s);
   }
 
-  :global(.leo-menu-popup ::slotted(leo-option:first-child)),
-  :global(.leo-menu-popup ::slotted(leo-menu-item:first-child)),
+  :global(.leo-menu-popup ::slotted(leo-option:nth-child(1 of :not([slot])))),
+  :global(.leo-menu-popup ::slotted(leo-menu-item:nth-child(1 of :not([slot])))),
   :global(.leo-menu-popup leo-option:first-child),
   :global(.leo-menu-popup leo-menu-item:first-child) {
     --leo-menu-item-margin: var(--leo-spacing-s) var(--leo-spacing-s) 0 var(--leo-spacing-s);
   }
-  :global(.leo-menu-popup ::slotted(leo-option:last-child)),
-  :global(.leo-menu-popup ::slotted(leo-menu-item:last-child)),
+  :global(.leo-menu-popup ::slotted(leo-option:nth-last-child(1 of :not([slot])))),
+  :global(.leo-menu-popup ::slotted(leo-menu-item:nth-last-child(1 of :not([slot])))),
   :global(.leo-menu-popup leo-option:last-child),
   :global(.leo-menu-popup leo-menu-item:last-child) {
     --leo-menu-item-margin: 0 var(--leo-spacing-s) var(--leo-spacing-s) var(--leo-spacing-s);


### PR DESCRIPTION
https://www.w3.org/TR/selectors-4/#the-nth-child-pseudo

(look for Example 49 for some explanation)

Basically, this selects:

A `leo-menu-item`/`leo-option` if:
1. Its the first child without a `slot` attribute
2. Its the last child without a `slot` attribute

This will fix (when merged) https://github.com/brave/brave-browser/issues/49013

FWIW, this feature is CSS baseline 2023, so should be all good for support!
https://caniuse.com/css-nth-child-of