### PR TITLE
[ButtonMenu]: Fix margin for single item

### DIFF
--- a/src/components/menu/menu.svelte
+++ b/src/components/menu/menu.svelte
@@ -258,7 +258,7 @@
   /* custom items can fit in by making optional use of these variables */
   :global(.leo-menu-popup ::slotted(*)),
   :global(.leo-menu-popup > *) {
-    --leo-menu-item-margin: 0 var(--leo-spacing-s);
+    --leo-menu-item-margin: var(--leo-menu-item-margin-top, 0) var(--leo-spacing-s) var(--leo-menu-item-margin-bottom, 0) var(--leo-spacing-s);
     --leo-menu-item-padding:  var(--leo-spacing-m) var(--leo-spacing-xl);
     --leo-menu-item-border-radius: var(--leo-spacing-s);
   }
@@ -267,13 +267,13 @@
   :global(.leo-menu-popup ::slotted(leo-menu-item:nth-child(1 of :not([slot])))),
   :global(.leo-menu-popup leo-option:first-child),
   :global(.leo-menu-popup leo-menu-item:first-child) {
-    --leo-menu-item-margin: var(--leo-spacing-s) var(--leo-spacing-s) 0 var(--leo-spacing-s);
+    --leo-menu-item-margin-top: var(--leo-spacing-s);
   }
   :global(.leo-menu-popup ::slotted(leo-option:nth-last-child(1 of :not([slot])))),
   :global(.leo-menu-popup ::slotted(leo-menu-item:nth-last-child(1 of :not([slot])))),
   :global(.leo-menu-popup leo-option:last-child),
   :global(.leo-menu-popup leo-menu-item:last-child) {
-    --leo-menu-item-margin: 0 var(--leo-spacing-s) var(--leo-spacing-s) var(--leo-spacing-s);
+    --leo-menu-item-margin-bottom: var(--leo-spacing-s);
   }
   :global(.leo-menu-popup ::slotted(leo-title)),
   :global(.leo-menu-popup leo-title) {


### PR DESCRIPTION
When there was just a single item the bottom margin was overriding the top one. Solution is to set the top/bottom padding separately.