### PR TITLE
[Menu]: Close on window blur

### DIFF
--- a/src/components/menu/menu.svelte
+++ b/src/components/menu/menu.svelte
@@ -170,7 +170,7 @@
     e.preventDefault() // preventDefault, so we don't accidentally scroll
   }
 
-  function handleBlur(e: MouseEvent) {
+  function handleBlur(e: Event) {
     dispatchClose(e, 'blur')
   }
 

--- a/src/svelteDirectives/clickOutside.ts
+++ b/src/svelteDirectives/clickOutside.ts
@@ -1,4 +1,4 @@
-type Handler = (e: MouseEvent) => void
+type Handler = (e: Event) => void
 
 export default function clickOutside(
   node: HTMLUnknownElement,
@@ -6,9 +6,12 @@ export default function clickOutside(
 ) {
   let lastHandler: Handler
   const attachHandler = (handler: Handler) => {
-    if (lastHandler) document.removeEventListener('click', lastHandler)
+    if (lastHandler) {
+      document.removeEventListener('click', lastHandler)
+      window.removeEventListener('blur', lastHandler)
+    }
 
-    lastHandler = (e: MouseEvent) => {
+    lastHandler = (e: Event) => {
       const path = e.composedPath()
       if (path.includes(node)) return
 
@@ -16,12 +19,14 @@ export default function clickOutside(
     }
 
     document.addEventListener('click', lastHandler)
+    window.addEventListener('blur', lastHandler)
   }
   attachHandler(handler)
 
   return {
     destroy() {
       document.removeEventListener('click', lastHandler)
+      window.removeEventListener('blur', lastHandler)
     },
     update(handler: Handler) {
       attachHandler(handler)


### PR DESCRIPTION
In AI Chat, none of the menus close when you click outside the current frame which results in a bad user experience. Menus should close when the frame loses focus.