### PR TITLE
[ButtonMenu]: Close when clicking the anchor for another  menu

### DIFF
--- a/src/components/buttonMenu/buttonMenu.stories.svelte
+++ b/src/components/buttonMenu/buttonMenu.stories.svelte
@@ -22,6 +22,7 @@
   import Slot from '../../storyHelpers/Slot.svelte'
   import Toggle from '../toggle/toggle.svelte'
   import Checkbox from '../checkbox/checkbox.svelte'
+  import Button from '../button/button.svelte'
 
   let toggleIsChecked = false
   let controlledMenuOpen = false
@@ -144,6 +145,21 @@
   </ButtonMenu>
 </Story>
 
+<Story name="Multiple Menus" let:args>
+  <div class="multi">
+    <ButtonMenu {...args}>
+      <Button slot="anchor-content">Anchor 1</Button>
+      <leo-menu-item>First</leo-menu-item>
+      <leo-menu-item>Second</leo-menu-item>
+    </ButtonMenu>
+    <ButtonMenu {...args}>
+      <Button slot="anchor-content">Anchor 2</Button>
+      <leo-menu-item>Third</leo-menu-item>
+      <leo-menu-item>Fourth</leo-menu-item>
+    </ButtonMenu>
+  </div>
+</Story>
+
 <style>
   .container {
     width: 300px;
@@ -171,5 +187,10 @@
     padding: var(--leo-menu-item-padding);
     font: var(--leo-font-small-regular);
     color: var(--leo-color-text-secondary);
+  }
+
+  .multi {
+    display: flex;
+    gap: 10px;
   }
 </style>

--- a/src/components/buttonMenu/buttonMenu.svelte
+++ b/src/components/buttonMenu/buttonMenu.svelte
@@ -35,9 +35,14 @@
   }
 
   const close: CloseEvent = (e) => {
+    if (e.originalEvent.composedPath().includes(anchor) || onClose?.(e) === false) {
+      return false
+    } else if ('key' in e) {
+      anchor.focus()
+    }
+
     if (isOpen === undefined) isOpenInternal = false
     onChange?.({ isOpen: false })
-    onClose?.(e)
   }
 </script>
 
@@ -49,7 +54,7 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <div 
     bind:this={anchor} 
-    on:click|preventDefault|stopPropagation={toggle}
+    on:click={toggle}
     role="button"
     aria-haspopup="menu"
     aria-expanded={isOpenInternal}


### PR DESCRIPTION
Previously, when clicking the anchor of another ButtonMenu while a different menu was open you'd end up with two menus open