### PR TITLE
[Menu]: Make it possible to prevent menu from growing

### DIFF
--- a/src/components/buttonMenu/buttonMenu.stories.svelte
+++ b/src/components/buttonMenu/buttonMenu.stories.svelte
@@ -155,7 +155,7 @@
     <ButtonMenu {...args}>
       <Button slot="anchor-content">Anchor 2</Button>
       <leo-menu-item>Third</leo-menu-item>
-      <leo-menu-item>Fourth</leo-menu-item>
+      <leo-menu-item>Fourth Fourth Fourth Fourth Fourth Fourth</leo-menu-item>
     </ButtonMenu>
   </div>
 </Story>

--- a/src/components/buttonMenu/buttonMenu.svelte
+++ b/src/components/buttonMenu/buttonMenu.svelte
@@ -23,6 +23,7 @@
   export let positionStrategy: Strategy = 'absolute'
   export let placement: Placement = 'bottom-start'
   export let flip: boolean = true
+  export let widthIsMaxWidth: boolean = false
 
   let anchor: HTMLElement
 
@@ -67,6 +68,7 @@
       {placement}
       {positionStrategy}
       {flip}
+      {widthIsMaxWidth}
       isOpen={isOpenInternal} 
       target={anchor} 
       onClose={close}

--- a/src/components/dropdown/dropdown.svelte
+++ b/src/components/dropdown/dropdown.svelte
@@ -30,6 +30,7 @@
   export let mode: Mode = 'outline'
   export let showErrors = false
   export let positionStrategy: Strategy = 'absolute'
+  export let widthIsMaxWidth: boolean = false
 
   export let onChange: (detail: SelectItemEventDetail) => void = undefined
   export let onClose: CloseEvent = undefined
@@ -87,6 +88,7 @@
   <Menu
     target={dropdown}
     {positionStrategy}
+    {widthIsMaxWidth}
     bind:isOpen
     bind:currentValue={value}
     onSelectItem={onChange}

--- a/src/components/menu/menu.svelte
+++ b/src/components/menu/menu.svelte
@@ -42,8 +42,11 @@
   export let positionStrategy: Strategy = 'absolute'
   export let placement: Placement = 'bottom-start'
   export let flip: boolean = true
-  export let onClose: CloseEvent =
-    undefined
+
+  /* If true the popup will be the same width as the control. By default it will grow to fit the menu items */
+  export let widthIsMaxWidth: boolean = false
+
+  export let onClose: CloseEvent = undefined
   export let onSelectItem: (detail: SelectItemEventDetail) => void = undefined
 
   function dispatchClose(
@@ -192,11 +195,12 @@
       {positionStrategy}
     >
       <div
+        style:--leo-menu-control-width={`${minWidth}px`}
         class="leo-menu-popup"
+        class:width-is-max-width={widthIsMaxWidth}
         id="menu"
         role="menu"
         tabindex="-1"
-        style:--leo-menu-control-width={`${minWidth}px`}
         bind:this={popup}
         on:keypress={(e) => {
           if (e.code !== 'Enter' && e.code !== 'Space') return
@@ -242,6 +246,11 @@
     display: flex;
     flex-direction: column;
     gap: var(--leo-spacing-s);
+
+    &.width-is-max-width {
+      width: var(--leo-menu-control-width);
+      overflow: hidden;
+    }
   }
 
   @keyframes menuIn {


### PR DESCRIPTION
Disabled (default, current behavior). As content gets wider menu gets wider:
<img width="358" height="196" alt="image" src="https://github.com/user-attachments/assets/4ab44de2-2889-4ae2-9058-a7498de88f70" />

Enabled. Menu does not grow with content width:
<img width="178" height="301" alt="image" src="https://github.com/user-attachments/assets/4f3eab18-25fa-4f70-b49f-60bcca331535" />