### PR TITLE
[Icons]: Fix auto updater which broke due to rate limiting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "babel-loader": "9.2.1",
         "css-loader": "6.11.0",
         "css-tree": "2.3.1",
-        "figma-api-exporter": "github:brave/figma-api-exporter#edd8385c12bd9c7bd26fa48b79ca67c3a5b80cce",
+        "figma-api-exporter": "github:brave/figma-api-exporter#141c3eab4643ba9cdcbb23867785aa7df9347eec",
         "jsdom": "21.1.2",
         "lodash.camelcase": "4.3.0",
         "lodash.merge": "4.6.2",
@@ -7050,8 +7050,8 @@
     },
     "node_modules/figma-api-exporter": {
       "version": "0.0.2",
-      "resolved": "git+ssh://git@github.com/brave/figma-api-exporter.git#edd8385c12bd9c7bd26fa48b79ca67c3a5b80cce",
-      "integrity": "sha512-HPPwhDhL+5W8ENSp2Pg1eGwhavjnnC9pv7fsapc7+xwMPlgX95mPyL8SeLTsyppy+ThE/aRTD+NPNuOhBO+ucg==",
+      "resolved": "git+ssh://git@github.com/brave/figma-api-exporter.git#141c3eab4643ba9cdcbb23867785aa7df9347eec",
+      "integrity": "sha512-4jntyvzLKOemDRVwpRQXh5YuxgU0Dxfc79qQsZDQKtR8LL/kLG/Kxuxm9jY4i7PZUTEyMoo1nVe0NRSLT14ojQ==",
       "dev": true
     },
     "node_modules/file-entry-cache": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "babel-loader": "9.2.1",
     "css-loader": "6.11.0",
     "css-tree": "2.3.1",
-    "figma-api-exporter": "github:brave/figma-api-exporter#edd8385c12bd9c7bd26fa48b79ca67c3a5b80cce",
+    "figma-api-exporter": "github:brave/figma-api-exporter#141c3eab4643ba9cdcbb23867785aa7df9347eec",
     "jsdom": "21.1.2",
     "lodash.camelcase": "4.3.0",
     "lodash.merge": "4.6.2",


### PR DESCRIPTION
I updated `figma-api-exporter` to handle being rate limited