### PR TITLE
**BREAKING** [Tokens]: Revise universal color palette and tokens

### DIFF
--- a/src/tokens/universal.variables.json
+++ b/src/tokens/universal.variables.json
@@ -1034,7 +1034,7 @@
         },
         "35": {
           "type": "color",
-          "value": "#6f1bdb"
+          "value": "#6116c0"
         },
         "40": {
           "type": "color",


### PR DESCRIPTION
- PR that revises the saturation of color token shades from 90 to 35 in order to get a mix of saturated vs. desaturated values.
- This also removes the need of having a -vibrant variation of the palette since now we get a mix on each color


## Before
<img width="1218" height="1218" alt="image" src="https://github.com/user-attachments/assets/5c74f99b-ab52-4678-9e65-db25bd3b3ef5" />

<img width="1404" height="1201" alt="image" src="https://github.com/user-attachments/assets/13dc2d89-77e0-4fd0-98d6-e79e5105ec34" />

## After

<img width="1201" height="1093" alt="image" src="https://github.com/user-attachments/assets/cda831dc-b41f-48f6-ab3c-b3de63a2f150" />

<img width="1394" height="1056" alt="image" src="https://github.com/user-attachments/assets/542f34b2-9e84-41f3-815f-2cda857544a7" />
