### PR TITLE
[Menu]: Handle Touch End for iOS

### DIFF
--- a/src/components/menu/menu.svelte
+++ b/src/components/menu/menu.svelte
@@ -166,6 +166,29 @@
   }
 
   /**
+   * On iOS, focusable items in a role="menu" get a two-tap behavior: first tap
+   * focuses the item, second tap activates. We want one tap to select. This
+   * touchend handler runs on first tap, finds the item under the touch, then
+   * preventDefault() + programmatic item.click() so selection happens immediately.
+   * Keyboard is unaffected (touchend only fires for touch).
+   * We find the item from composedPath() and popup (not the menuItems array) so
+   * this works reliably when the menu is reopened and the array may be stale.
+   */
+  function handleTouchEnd(e: TouchEvent) {
+    const path = e.composedPath()
+    const item = path.find(
+      (el): el is MenuItem =>
+        el instanceof HTMLElement &&
+        (el.tagName === 'LEO-MENU-ITEM' || el.tagName === 'LEO-OPTION') &&
+        !!popup?.contains(el)
+    )
+    if (item) {
+      e.preventDefault()
+      item.click()
+    }
+  }
+
+  /**
    * Handles changing the currently focused menu element with the up/down arrow.
    * @param e The KeyboardEvent
    */
@@ -236,6 +259,7 @@
           selectMenuItem(e)
         }}
         on:click={selectMenuItem}
+        on:touchend={handleTouchEnd}
       >
         <slot />
       </div>


### PR DESCRIPTION
Fix iOS single-tap for menu items (leo-menu-item / leo-option)

On iOS, the first tap on a menu item only focused it; a second tap was needed to select. This adds a touchend handler on the menu popup that finds the touched item and programmatically triggers a click on first tap, so one tap selects. Keyboard behavior is unchanged.