### PR TITLE
Add data attribute support to react wrapper

### DIFF
--- a/src/components/button/button.svelte
+++ b/src/components/button/button.svelte
@@ -49,8 +49,6 @@
   export let href: Href = undefined
   export let fab = false
 
-  export let dataTestId: string | undefined = undefined
-
   export let onClick: (e: MouseEvent) => void = undefined
 
   /**
@@ -85,7 +83,6 @@
   class:isLoading
   on:click={onClick}
   {...$$restProps}
-  data-test-id={dataTestId || undefined}
   disabled={isLoading || disabled || undefined}
 >
   {#if isLoading}

--- a/src/components/svelte-react.ts
+++ b/src/components/svelte-react.ts
@@ -44,6 +44,9 @@ export type ReactProps<Props> = Props & {
   // available on all elements. We just want to make sure we have the correct
   // React name/value for them.
   [P in IntrinsicProps]?: Omit<JSX.IntrinsicElements, 'ref'>['div'][P]
+} & {
+  // Allow data-* attributes for test selectors and other uses.
+  [key: `data-${string}`]: string | undefined
 }
 
 const useEventHandlers = (props: any) => {
@@ -147,9 +150,16 @@ export default function SvelteWebComponentToReact<
         }
       }, [props])
 
+      // Forward data-* attributes to the host element so they are
+      // visible outside the shadow DOM (e.g. for test selectors).
+      const dataAttrs = Object.fromEntries(
+        Object.entries(props).filter(([key]) => key.startsWith('data-'))
+      )
+
       return createElement(tag, {
         ref: setRef,
-        children: props.children
+        children: props.children,
+        ...dataAttrs
       })
     }
   )


### PR DESCRIPTION
Forward data-* attributes (e.g. data-test-id) from React props to the host custom element, so they are visible in the DOM outside the shadow root. Also adds TypeScript support for data-* attributes on all Leo React components.