### PR TITLE
[android]: Set default color on icons

### DIFF
--- a/src/scripts/gen-android-icons.ts
+++ b/src/scripts/gen-android-icons.ts
@@ -5,6 +5,11 @@ import svg2vectordrawable from 'svg2vectordrawable'
 const ICONS_FOLDER = 'icons/'
 const OUTPUT_FOLDER = './tokens/android/drawable/'
 
+const isColor = (icon: string) =>
+  icon.endsWith('-color.svg') ||
+  icon.includes('social') ||
+  icon.includes('country')
+
 fs.mkdir(OUTPUT_FOLDER, { recursive: true })
   .then(() => fs.readdir(ICONS_FOLDER))
   .then((icons) => icons.filter((i) => i.endsWith('.svg')))
@@ -17,6 +22,13 @@ fs.mkdir(OUTPUT_FOLDER, { recursive: true })
         const outputFileName = `ic_${path
           .basename(icon, '.svg')
           .replaceAll('-', '_')}.xml`
+
+        if (!isColor(icon)) {
+          vectorContent = vectorContent.replaceAll(
+            /android:fillColor="#\w+?"/g,
+            'android:fillColor="@color/icon_default"'
+          )
+        }
         fs.writeFile(path.join(OUTPUT_FOLDER, outputFileName), vectorContent)
       })
     })


### PR DESCRIPTION
This PR updates the android icons to use `@color/icon_default` as their fill color