### PR TITLE
[android]: Allow transparency in color tokens

### DIFF
--- a/src/tokens/transformation/android/formats/colorStyle.js
+++ b/src/tokens/transformation/android/formats/colorStyle.js
@@ -2,13 +2,19 @@ import StyleDictionary from 'style-dictionary'
 import { TinyColor } from '@ctrl/tinycolor'
 const { fileHeader } = StyleDictionary.formatHelpers
 
+const getTokenValue = (token) => {
+  const color = new TinyColor(token.original.value)
+  if (color.getAlpha() === 1) {
+    return color.toHexString()
+  }
+  return color.toHex8String()
+}
+
 export default ({ dictionary, platform, options = {}, file }) => {
   const colorStyles = dictionary.allTokens
     .filter((compositeToken) => compositeToken.type === 'color')
     .map((compositeToken) => {
-      const colorCode = new TinyColor(
-        compositeToken.original.value
-      ).toHexString()
+      const colorCode = getTokenValue(compositeToken)
       return `  <color name="${compositeToken.name}" tools:ignore="UnusedResources">${colorCode}</color>`
     })
   return `<?xml version="1.0" encoding="utf-8" ?>


### PR DESCRIPTION
previously we'd drop the alpha channel