### PR TITLE
[svelte5]: Use unmount not destroy

### DIFF
--- a/src/components/alert/alert.svelte
+++ b/src/components/alert/alert.svelte
@@ -138,7 +138,7 @@
       align-content: center;
     }
 
-    &:has(.content-after) .content-after {
+    & .content-after {
       grid-row: main;
       grid-column: -1; // No named track necessary as it should just always be at the end.
     }
@@ -154,8 +154,10 @@
         grid-column: main-end; // Actions for `.inline-actions` should always be after the `main` content
       }
 
-      // If both `actions` and `content-after` exist, we have to add at least an explicit track for content-after since -1 doesn't work for implicit tracks
-      &:has(.content-after):has(.actions) {
+      // If both `actions` and `content-after` exist, we have to add at least an explicit track for content-after since -1 doesn't work for implicit tracks.
+      // The two children are combined into a single `:has()` with a sibling combinator (rather than two chained `:has()`) because jsdom's nwsapi
+      // selector engine fails to parse chained `:has(...:where(...))` selectors that Svelte 5 generates for scoped CSS.
+      &:has(.content-after ~ .actions) {
         grid-template-columns: [icon-start] min-content [icon-end main-start] 1fr [main-end content-after] auto [content-end];
       }
     }

--- a/src/components/dialog/dialog.svelte
+++ b/src/components/dialog/dialog.svelte
@@ -245,7 +245,10 @@
   }
 
   :host .leo-dialog .actions .body,
-  .leo-dialog.hasActions:has(:global([slot=actions]:not(:empty))) .body {
+  // The `:has()` is moved onto `.body` (rather than `.leo-dialog`) so that no descendant
+  // selector follows the `:has()`. jsdom's nwsapi selector engine fails to parse selectors
+  // of the form `<X>:has(...) <Y>:where(...)` that Svelte 5 generates for scoped CSS.
+  .leo-dialog.hasActions .body:has(~ .actions :global([slot=actions]:not(:empty))) {
     padding-bottom: 0;
   }
 

--- a/src/components/svelte-web.ts
+++ b/src/components/svelte-web.ts
@@ -249,7 +249,7 @@ export default function registerWebComponent(
 
     disconnectedCallback() {
       this.#lastSlots = new Set()
-      this.component?.$destroy()
+      if (this.component) unmount(this.component)
       this.#component = null
     }
 


### PR DESCRIPTION
$destroy doesn't exist in Svelte5, its been replaced by umount

also fixes some CSS selectors which were breaking Jest