### PR TITLE
[react]: Use useLayoutEffect instead of useEffect in svelte-react.ts

### DIFF
--- a/src/components/svelte-react.ts
+++ b/src/components/svelte-react.ts
@@ -7,7 +7,8 @@ import {
   type ForwardedRef,
   type PropsWithChildren,
   useState,
-  type PropsWithoutRef
+  type PropsWithoutRef,
+  useLayoutEffect
 } from 'react'
 import type { SvelteComponent } from 'svelte'
 
@@ -137,7 +138,7 @@ export default function SvelteWebComponentToReact<
         [setElement]
       )
 
-      useEffect(() => {
+      useLayoutEffect(() => {
         if (!component.current) return
         // Create a dictionary of all our properties without events. If we pass an
         // onClick prop through to Svelte, we could inadvertently set it on the


### PR DESCRIPTION
This avoids a potential flash of the component with the default props before useEffect runs.