### PR TITLE
Update dialog.svelte padding to match Design system in Figma

### DIFF
--- a/src/components/dialog/dialog.svelte
+++ b/src/components/dialog/dialog.svelte
@@ -293,7 +293,7 @@
 
   @media (min-width: 480px) and (min-height: 480px) {
     .leo-dialog {
-      --padding: var(--leo-dialog-padding, var(--leo-spacing-4xl));
+      --padding: var(--leo-dialog-padding, var(--leo-spacing-3xl));
       max-width: var(--leo-dialog-width, 500px);
     }
 


### PR DESCRIPTION
Made the general padding a little smaller, moving from 4xl to 3xl