### PR TITLE
chore: Domain migration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           for filePath in ./tokens/css/variables*.css; do
             fileName=${filePath/.\/tokens\/css\//}
-            reqStatus=$(curl -sL --write-out "%{http_code}" -o ./tokens/css/${fileName/%.css/.old.css} https://nala.bravesoftware.com/css/$fileName)
+            reqStatus=$(curl -sL --write-out "%{http_code}" -o ./tokens/css/${fileName/%.css/.old.css} https://nala.s.brave.dev/css/$fileName)
             # Note: Diff has exit code 1 for differences, and there are always
             # some differences because the file contains a timestamp.
             if [ -s ./tokens/css/file-sizes.diff ]; then

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,8 +83,8 @@ jobs:
               repo: context.repo.repo,
               body: `👋 Thanks for Submitting! This PR is available for preview at the link below.
 
-            ✅ PR tip preview: https://${{ github.event.workflow_run.pull_requests[0].number }}.pr.nala.bravesoftware.com/
-            ✅ Commit preview: https://${{ github.event.workflow_run.pull_requests[0].number }}.pr.nala.bravesoftware.com/commit-${{ github.event.workflow_run.head_sha }}/
+            ✅ PR tip preview: https://${{ github.event.workflow_run.pull_requests[0].number }}.pr-nala.s.brave.dev/
+            ✅ Commit preview: https://${{ github.event.workflow_run.pull_requests[0].number }}.pr-nala.s.brave.dev/commit-${{ github.event.workflow_run.head_sha }}/
 
             \`\`\`diff
             ${fileSizes}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ generated Skia/C++ token files live in the `nala::` namespace
 (see [tokens/skia/](tokens/skia/) and the templates under
 [src/tokens/transformation/skia/templates/](src/tokens/transformation/skia/templates/))
 and per-PR Storybook previews are deployed to
-`https://<pr-number>.pr.nala.bravesoftware.com/` by
+`https://<pr-number>.pr-nala.s.brave.dev/` by
 [.github/workflows/deploy.yml](.github/workflows/deploy.yml). For
 everything in this repo, "Leo" and "nala" refer to the same design system.
 


### PR DESCRIPTION
Replace all `*.bravesoftware.com` URLs with their `*.s.brave.dev` successors.

For https://github.com/brave/devops/issues/16198