### PR TITLE
Support React 19 in svelte-react wrapper

### DIFF
--- a/src/components/svelte-react.ts
+++ b/src/components/svelte-react.ts
@@ -8,7 +8,8 @@ import {
   type PropsWithChildren,
   useState,
   type PropsWithoutRef,
-  useLayoutEffect
+  useLayoutEffect,
+  type JSX
 } from 'react'
 import type { SvelteComponent } from 'svelte'
 
@@ -117,7 +118,7 @@ export default function SvelteWebComponentToReact<
       props: PropsWithoutRef<PropsWithChildren<T>>,
       forwardedRef: ForwardedRef<HTMLElement>
     ) => {
-      const component = useRef<HTMLElement>()
+      const component = useRef<HTMLElement>(null)
       const { setElement } = useEventHandlers(props)
 
       const setRef = useCallback(

--- a/src/components/svelte-react.ts
+++ b/src/components/svelte-react.ts
@@ -118,7 +118,7 @@ export default function SvelteWebComponentToReact<
       props: PropsWithoutRef<PropsWithChildren<T>>,
       forwardedRef: ForwardedRef<HTMLElement>
     ) => {
-      const component = useRef<HTMLElement>(null)
+      const component = useRef<HTMLElement | null>(null)
       const { setElement } = useEventHandlers(props)
 
       const setRef = useCallback(


### PR DESCRIPTION
React 19's @types/react removed the global JSX namespace (use React.JSX instead) and removed the zero-argument useRef overload. Import the JSX namespace explicitly from 'react' and provide an initial value to useRef so the wrapper compiles against both @types/react 18 and 19.