### PR TITLE
[Link]: Only use flex if icon(s) present

### DIFF
--- a/src/components/link/link.svelte
+++ b/src/components/link/link.svelte
@@ -54,6 +54,7 @@
   class="leoLink"
   class:disabled
   class:loading
+  class:hasIcon={loading || $$slots['icon-before'] || $$slots['icon-after']}
   aria-disabled={loading || disabled || undefined}
   on:click={onClick ||
     ((e) => {
@@ -100,10 +101,13 @@
     cursor: pointer;
     -webkit-tap-highlight-color: transparent;
     text-decoration: underline;
-    vertical-align: bottom;
-    display: inline-flex;
-    align-items: center;
-    gap: var(--leo-link-icon-gap, 0.3em);
+
+    &:where(.hasIcon) {
+      vertical-align: bottom;
+      display: inline-flex;
+      align-items: center;
+      gap: var(--leo-link-icon-gap, 0.3em);
+    }
 
     &:where(:hover) {
       color: var(--hover-color);


### PR DESCRIPTION
Brave.com uses the `Link` component as the default styling for `<a>` tags, however the change to support icons broke this since I set `display: inline-flex`. This ensures that it is only `display: inline-flex` when icons are present.