### PR TITLE
Add scrollable dialog & fix CSS selectors

### DIFF
--- a/src/components/dialog/dialog.stories.svelte
+++ b/src/components/dialog/dialog.stories.svelte
@@ -63,6 +63,10 @@
 
   let openDialog
   let isOpen = false
+  let scrollDialogOpen = false
+
+  const scrollParagraph =
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ipsum pharetra est et viverra massa enim aliquam. Volutpat tristique id mi blandit interdum elit quam commodo vel. Ac laoreet magna ac sed diam volutpat. Sit mauris, orci diam in habitasse nec dolor odio pharetra.'
 </script>
 
 <Template let:args>
@@ -77,15 +81,17 @@
       est et viverra massa enim aliquam. Volutpat tristique id mi blandit
       interdum elit quam commodo vel. Ac laoreet magna ac sed diam volutpat. Sit
       mauris, orci diam in habitasse nec dolor odio pharetra.
-
+      <div class="input-container">
+        <Input placeholder="This is an input field" />
+      </div>
       <div class="alert-container">
         <Alert>
           <div>This is an info box</div>
         </Alert>
       </div>
+      
     </div>
     <div slot="actions">
-      <Input placeholder="This is an input field" />
       <Button kind="outline">Secondary</Button>
       <Button kind="filled">Primary</Button>
     </div>
@@ -149,8 +155,46 @@
 
 <Story name="Show Close" args={{showClose: true}} />
 
+<Story name="Inner Scroll" let:args>
+  <Button isDisabled={scrollDialogOpen} onClick={() => (scrollDialogOpen = true)}
+    >Show Dialog</Button
+  >
+  <Dialog
+    {...args}
+    showClose
+    style="max-height: min(420px, calc(100vh - var(--leo-spacing-m) * 2)); overflow: auto;"
+    bind:isOpen={scrollDialogOpen}
+  >
+    <div slot="title">Scrollable dialog</div>
+    <div slot="subtitle">Scroll to see header and actions dividers</div>
+    <div class="scroll-content">
+      {#each { length: 8 } as _, i}
+        <p>{scrollParagraph} ({i + 1})</p>
+      {/each}
+    </div>
+    <div slot="actions">
+      <Button kind="outline" onClick={() => (scrollDialogOpen = false)}
+        >Cancel</Button
+      >
+      <Button kind="filled" onClick={() => (scrollDialogOpen = false)}
+        >Done</Button
+      >
+    </div>
+  </Dialog>
+</Story>
+
 <style>
   .alert-container {
     margin-top: var(--leo-spacing-xl);
+  }
+
+  .scroll-content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--leo-spacing-xl);
+  }
+
+  .scroll-content p {
+    margin: 0;
   }
 </style>

--- a/src/components/dialog/dialog.svelte
+++ b/src/components/dialog/dialog.svelte
@@ -169,10 +169,7 @@
   /** Since Svelte 4 doesn't support conditional slots in the consumer,
    * we only want to account for actions if there's actually content in the slot
    * however for webcomponents, we don't need to check for this, so we special
-   * case the selector with :host.
-   *
-   * Only the slotted `[slot=actions]` content is `:global` (it's projected in
-   * by the parent). `.leo-dialog`/`.actions` stay component-scoped by Svelte. */
+   * case the selector with :host. */
   :host .leo-dialog.hasActions,
   .leo-dialog.hasActions:has(:global([slot=actions]:not(:empty))) {
     grid-template-rows: auto auto;

--- a/src/components/dialog/dialog.svelte
+++ b/src/components/dialog/dialog.svelte
@@ -59,15 +59,15 @@
       if (escapeCloses) close()
     }}
   >
-    {#if showClose}
-      <div class="close-button">
-        <Button kind="plain-faint" fab onClick={close}>
-          <Icon name="close" />
-        </Button>
-      </div>
-    {/if}
     {#if hasHeader}
       <header>
+        {#if showClose}
+          <div class="close-button">
+            <Button kind="plain-faint" fab onClick={close}>
+              <Icon name="close" />
+            </Button>
+          </div>
+        {/if}
         {#if showBack || $$slots.title}
           <div class="title-row">
             {#if showBack}
@@ -88,6 +88,12 @@
           </div>
         {/if}
       </header>
+    {:else if showClose}
+      <div class="close-button">
+        <Button kind="plain-faint" fab onClick={close}>
+          <Icon name="close" />
+        </Button>
+      </div>
     {/if}
     <div class="body">
       <slot />
@@ -163,14 +169,18 @@
   /** Since Svelte 4 doesn't support conditional slots in the consumer,
    * we only want to account for actions if there's actually content in the slot
    * however for webcomponents, we don't need to check for this, so we special
-   * case the selector with :host. */
+   * case the selector with :host.
+   *
+   * Use `:global(.foo:has(...))` (not `:has(:global(...))`) so `:global` is
+   * stripped correctly — nested `:global` inside `:has` can leak into the CSS
+   * as an invalid rule and drop background/padding on `.actions`. */
   :host .leo-dialog.hasActions,
-  .leo-dialog.hasActions:has(:global([slot=actions]:not(:empty))) {
+  :global(.leo-dialog.hasActions:has([slot=actions]:not(:empty))) {
     grid-template-rows: auto auto;
   }
 
   :host .leo-dialog.hasHeader.hasActions,
-  .leo-dialog.hasHeader.hasActions:has(.actions :global([slot=actions]:not(:empty))) {
+  :global(.leo-dialog.hasHeader.hasActions:has(.actions [slot=actions]:not(:empty))) {
     grid-template-rows: auto auto auto;
   }
 
@@ -219,6 +229,16 @@
     top: var(--leo-spacing-xl);
   }
 
+  /* No header: keep the close control pinned while the dialog scrolls. */
+  .leo-dialog > .close-button {
+    position: sticky;
+    z-index: 2;
+    justify-self: end;
+    margin-inline-end: var(--leo-spacing-xl);
+    height: 0;
+    overflow: visible;
+  }
+
   .leo-dialog {
     .close-button,
     .back-button {
@@ -245,17 +265,36 @@
   }
 
   :host .leo-dialog .actions .body,
-  // The `:has()` is moved onto `.body` (rather than `.leo-dialog`) so that no descendant
-  // selector follows the `:has()`. jsdom's nwsapi selector engine fails to parse selectors
-  // of the form `<X>:has(...) <Y>:where(...)` that Svelte 5 generates for scoped CSS.
-  .leo-dialog.hasActions .body:has(~ .actions :global([slot=actions]:not(:empty))) {
+  :global(.leo-dialog.hasActions .body:has(~ .actions [slot=actions]:not(:empty))) {
     padding-bottom: 0;
   }
 
   :host .leo-dialog .actions,
-  .leo-dialog .actions:has(:global([slot=actions]:not(:empty))) {
+  :global(.leo-dialog .actions:has([slot=actions]:not(:empty))) {
     background: var(--background);
     padding: var(--padding);
+    position: sticky;
+    bottom: 0;
+    z-index: 1;
+
+    border-top: 1px solid transparent;
+
+    @supports (animation-timeline: scroll()) {
+      animation-timeline: scroll();
+      animation-range: 0% 100%;
+      animation-name: actions-scroll-border;
+      animation-duration: 1ms;
+      animation-fill-mode: none;
+    }
+  }
+
+  @keyframes actions-scroll-border {
+    from {
+      border-top-color: var(--leo-color-divider-subtle);
+    }
+    to {
+      border-top-color: transparent;
+    }
   }
 
   /** The below :global selectors are so that Svelte doesn't remove the classes
@@ -269,7 +308,7 @@
   .leo-dialog .actions :global(::slotted(*)),
   .leo-dialog .actions :global([slot='actions']:not(:empty)) {
     display: flex;
-    gap: var(--leo-spacing-xl);
+    gap: var(--leo-spacing-m);
     flex-direction: column;
     align-items: stretch;
     justify-content: end;

--- a/src/components/dialog/dialog.svelte
+++ b/src/components/dialog/dialog.svelte
@@ -171,16 +171,15 @@
    * however for webcomponents, we don't need to check for this, so we special
    * case the selector with :host.
    *
-   * Use `:global(.foo:has(...))` (not `:has(:global(...))`) so `:global` is
-   * stripped correctly — nested `:global` inside `:has` can leak into the CSS
-   * as an invalid rule and drop background/padding on `.actions`. */
+   * Only the slotted `[slot=actions]` content is `:global` (it's projected in
+   * by the parent). `.leo-dialog`/`.actions` stay component-scoped by Svelte. */
   :host .leo-dialog.hasActions,
-  :global(.leo-dialog.hasActions:has([slot=actions]:not(:empty))) {
+  .leo-dialog.hasActions:has(:global([slot=actions]:not(:empty))) {
     grid-template-rows: auto auto;
   }
 
   :host .leo-dialog.hasHeader.hasActions,
-  :global(.leo-dialog.hasHeader.hasActions:has(.actions [slot=actions]:not(:empty))) {
+  .leo-dialog.hasHeader.hasActions:has(.actions :global([slot=actions]:not(:empty))) {
     grid-template-rows: auto auto auto;
   }
 
@@ -265,12 +264,15 @@
   }
 
   :host .leo-dialog .actions .body,
-  :global(.leo-dialog.hasActions .body:has(~ .actions [slot=actions]:not(:empty))) {
+  // The `:has()` is moved onto `.body` (rather than `.leo-dialog`) so that no descendant
+  // selector follows the `:has()`. jsdom's nwsapi selector engine fails to parse selectors
+  // of the form `<X>:has(...) <Y>:where(...)` that Svelte 5 generates for scoped CSS.
+  .leo-dialog.hasActions .body:has(~ .actions :global([slot=actions]:not(:empty))) {
     padding-bottom: 0;
   }
 
   :host .leo-dialog .actions,
-  :global(.leo-dialog .actions:has([slot=actions]:not(:empty))) {
+  .leo-dialog .actions:has(:global([slot=actions]:not(:empty))) {
     background: var(--background);
     padding: var(--padding);
     position: sticky;


### PR DESCRIPTION
## Summary

Fixes dialog actions layout/CSS bugs and improves scrollable dialog behavior (sticky chrome, scroll dividers, close button).

### Bug fixes
- **Actions missing background & padding** — Actions layout now handles slotted action content without opting `.leo-dialog` / `.actions` out of Svelte component scoping. Only the projected `[slot=actions]` content is wrapped in `:global(...)`.
- **Close button scrolling away** — With inner scroll, the absolutely positioned close button scrolled with the content. It now lives inside the sticky header when a header is present; without a header it uses sticky positioning so it stays pinned.

### Scrollable dialog behavior
- **Sticky actions** — Actions stay pinned to the bottom of the scrollport while the body scrolls.
- **Scroll dividers** — Header already showed a bottom border via `animation-timeline: scroll()` when scrolled. Actions now get a matching top border that appears when more content can scroll and fades at the end of the scroll range.
- **Actions gap** — Spacing between action children tightened from `--leo-spacing-xl` to `--leo-spacing-m`.

### Stories
- Added **Inner Scroll** story: height-capped dialog (`max-height` + `overflow: auto`), long body content, sticky header/actions with scroll dividers, close button, and Cancel/Done actions.
- Default template: moved the sample `Input` from the actions slot into the body (actions are buttons only).

## Test plan
- [ ] Open **Components / Dialog / Default** — actions sit inside the card with padding and background
- [ ] Open **Inner Scroll** — dialog scrolls within max-height; header and actions stay pinned
- [ ] On Inner Scroll, scroll the body — header bottom divider and actions top divider appear/update with scroll
- [ ] On Inner Scroll (and Show Close), close button stays fixed in the header while content scrolls
- [ ] Dialog without title/subtitle but with `showClose` — close still stays pinned while scrolling
- [ ] Short dialogs (Default / Show Close) — no stray actions top border when content does not overflow
- [ ] React / web-component consumers still get actions styling via `:host` rules
- [ ] Mobile vs desktop: actions stack in portrait / smaller sizes and row-align on larger viewports
- [ ] `npx jest`