### PR TITLE
Dialog: add configurable close button position

### DIFF
--- a/src/components/dialog/dialog.stories.svelte
+++ b/src/components/dialog/dialog.stories.svelte
@@ -41,13 +41,20 @@
       'isOpen': {
         'control': 'none'
       },
+      'closePosition': {
+        'control': 'select',
+        'options': ['inline', 'outside'],
+        'description':
+          'Where to place the close button when showClose is enabled'
+      },
       'size': {
         'control': 'select',
         'options': ['mobile', 'normal']
       }
     },
     args: {
-      'isOpen': false
+      'isOpen': false,
+      'closePosition': 'inline'
     }
   }
 </script>
@@ -64,6 +71,8 @@
   let openDialog
   let isOpen = false
   let scrollDialogOpen = false
+  let closeInlineOpen = true
+  let closeOutsideOpen = true
 
   const scrollParagraph =
     'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ipsum pharetra est et viverra massa enim aliquam. Volutpat tristique id mi blandit interdum elit quam commodo vel. Ac laoreet magna ac sed diam volutpat. Sit mauris, orci diam in habitasse nec dolor odio pharetra.'
@@ -153,7 +162,59 @@
 
 <Story name="Default" />
 
-<Story name="Show Close" args={{showClose: true}} />
+<Story name="Show Close Inline" let:args>
+  <Button
+    isDisabled={closeInlineOpen}
+    onClick={() => (closeInlineOpen = true)}>Show Dialog</Button
+  >
+  <Dialog
+    {...args}
+    showClose
+    closePosition="inline"
+    bind:isOpen={closeInlineOpen}
+  >
+    <div slot="title">This is the title</div>
+    <div slot="subtitle">This is the subtitle</div>
+    <div>
+      Close control is shown inline in the dialog header.
+    </div>
+    <div slot="actions">
+      <Button kind="outline" onClick={() => (closeInlineOpen = false)}
+        >Secondary</Button
+      >
+      <Button kind="filled" onClick={() => (closeInlineOpen = false)}
+        >Primary</Button
+      >
+    </div>
+  </Dialog>
+</Story>
+
+<Story name="Show Close Outside" let:args>
+  <Button
+    isDisabled={closeOutsideOpen}
+    onClick={() => (closeOutsideOpen = true)}>Show Dialog</Button
+  >
+  <Dialog
+    {...args}
+    showClose
+    closePosition="outside"
+    bind:isOpen={closeOutsideOpen}
+  >
+    <div slot="title">This is the title</div>
+    <div slot="subtitle">This is the subtitle</div>
+    <div>
+      Close control is shown outside the dialog, above the top-right corner.
+    </div>
+    <div slot="actions">
+      <Button kind="outline" onClick={() => (closeOutsideOpen = false)}
+        >Secondary</Button
+      >
+      <Button kind="filled" onClick={() => (closeOutsideOpen = false)}
+        >Primary</Button
+      >
+    </div>
+  </Dialog>
+</Story>
 
 <Story name="Inner Scroll" let:args>
   <Button isDisabled={scrollDialogOpen} onClick={() => (scrollDialogOpen = true)}
@@ -162,6 +223,7 @@
   <Dialog
     {...args}
     showClose
+    closePosition="inline"
     style="max-height: min(420px, calc(100vh - var(--leo-spacing-m) * 2)); overflow: auto;"
     bind:isOpen={scrollDialogOpen}
   >

--- a/src/components/dialog/dialog.svelte
+++ b/src/components/dialog/dialog.svelte
@@ -4,10 +4,14 @@
   import Button from '../button/button.svelte'
   import Icon from '../icon/icon.svelte'
 
+  type ClosePosition = 'inline' | 'outside'
+
   type $$Props = Omit<Partial<SvelteHTMLElements['dialog']>, 'open'> & {
     isOpen?: boolean
     modal?: boolean
     showClose?: boolean
+    /** Where to place the close button when `showClose` is true. Defaults to `inline`. */
+    closePosition?: ClosePosition
     showBack?: boolean
     escapeCloses?: boolean
     backdropClickCloses?: boolean
@@ -19,6 +23,7 @@
   export let isOpen = false
   export let modal = true
   export let showClose = false
+  export let closePosition: ClosePosition = 'inline'
   export let showBack = false
   export let escapeCloses = true
   export let backdropClickCloses = true
@@ -35,6 +40,9 @@
 
   const hasHeader = showBack || $$slots.title || $$slots.subtitle
 
+  $: showCloseInline = showClose && closePosition === 'inline'
+  $: showCloseOutside = showClose && closePosition === 'outside'
+
   const close = () => {
     isOpen = false
     onClose?.()
@@ -49,6 +57,7 @@
     class:modal
     class:hasHeader
     class:hasActions={$$slots.actions}
+    class:hasCloseOutside={showCloseOutside}
     bind:this={dialog}
     on:close={close}
     on:cancel={(e) => {
@@ -59,9 +68,16 @@
       if (escapeCloses) close()
     }}
   >
+    {#if showCloseOutside}
+      <div class="close-button outside">
+        <Button kind="plain-faint" fab onClick={close}>
+          <Icon name="close" />
+        </Button>
+      </div>
+    {/if}
     {#if hasHeader}
       <header>
-        {#if showClose}
+        {#if showCloseInline}
           <div class="close-button">
             <Button kind="plain-faint" fab onClick={close}>
               <Icon name="close" />
@@ -88,7 +104,7 @@
           </div>
         {/if}
       </header>
-    {:else if showClose}
+    {:else if showCloseInline}
       <div class="close-button">
         <Button kind="plain-faint" fab onClick={close}>
           <Icon name="close" />
@@ -219,14 +235,50 @@
     font: var(--leo-font-heading-h2);
   }
 
+  /* Keep overflow visible so the outside close isn't clipped, and round the
+   * painted surfaces directly (the dialog background is transparent). */
+  .leo-dialog.hasCloseOutside {
+    overflow: visible;
+
+    &.hasHeader > header {
+      border-start-start-radius: var(--border-radius);
+      border-start-end-radius: var(--border-radius);
+    }
+
+    &:not(.hasHeader) > .body {
+      border-start-start-radius: var(--border-radius);
+      border-start-end-radius: var(--border-radius);
+    }
+
+    &.hasActions > .actions {
+      border-end-start-radius: var(--border-radius);
+      border-end-end-radius: var(--border-radius);
+    }
+
+    &:not(.hasActions) > .body {
+      border-end-start-radius: var(--border-radius);
+      border-end-end-radius: var(--border-radius);
+    }
+  }
+
   .leo-dialog .close-button {
     position: absolute;
     inset-inline-end: var(--leo-spacing-xl);
     top: var(--leo-spacing-xl);
   }
 
+  .leo-dialog .close-button.outside {
+    inset-inline-end: 0;
+    top: auto;
+    bottom: 100%;
+    margin-bottom: var(--leo-spacing-m);
+    --leo-button-color: var(--leo-color-icon-default);
+    --leo-icon-color: var(--leo-color-icon-default);
+    color: var(--leo-color-icon-default);
+  }
+
   /* No header: keep the close control pinned while the dialog scrolls. */
-  .leo-dialog > .close-button {
+  .leo-dialog > .close-button:not(.outside) {
     position: sticky;
     z-index: 2;
     justify-self: end;

--- a/src/components/dialog/dialog.svelte
+++ b/src/components/dialog/dialog.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { SvelteHTMLElements } from 'svelte/elements'
+  import { onMount } from 'svelte'
   import { scale } from 'svelte/transition'
   import Button from '../button/button.svelte'
   import Icon from '../icon/icon.svelte'
@@ -34,14 +35,32 @@
 
   let dialog: HTMLDialogElement
 
+  // Matches the dialog's compact layout breakpoint (below 480×480).
+  const compactViewportQuery = '(max-width: 479px), (max-height: 479px)'
+  let isCompactViewport =
+    typeof window !== 'undefined' &&
+    window.matchMedia(compactViewportQuery).matches
+
+  onMount(() => {
+    const mediaQuery = window.matchMedia(compactViewportQuery)
+    const update = () => {
+      isCompactViewport = mediaQuery.matches
+    }
+    update()
+    mediaQuery.addEventListener('change', update)
+    return () => mediaQuery.removeEventListener('change', update)
+  })
+
   $: {
     if (isOpen && !dialog?.open && dialog?.isConnected) dialog?.showModal()
   }
 
   const hasHeader = showBack || $$slots.title || $$slots.subtitle
 
-  $: showCloseInline = showClose && closePosition === 'inline'
-  $: showCloseOutside = showClose && closePosition === 'outside'
+  // Outside close needs space above the dialog; fall back to inline on compact viewports.
+  $: closeIsOutside = closePosition === 'outside' && !isCompactViewport
+  $: showCloseInline = showClose && !closeIsOutside
+  $: showCloseOutside = showClose && closeIsOutside
 
   const close = () => {
     isOpen = false


### PR DESCRIPTION
## Summary
- Adds a `closePosition` prop to Dialog (`'inline' | 'outside'`) that controls where the close button is rendered when `showClose` is enabled. Defaults to `'inline'`, so existing `showClose` usage is unchanged.
- **Inline** keeps the current behavior: close button inside the dialog (header when present, otherwise pinned at the top).
- **Outside** places the close button above the dialog, right-aligned to the top-right corner with an 8px (`--leo-spacing-m`) gap, using `--leo-color-icon-default` as the default icon/button color.
- Outside close stays a child of `<dialog>` (so it remains in the top layer for modals) with `overflow: visible`. Because the dialog background is transparent, header/body/actions get matching border radii so corners still look correct.
- **Responsive fallback:** when `closePosition="outside"` but the viewport is compact (below the dialog’s 480×480 breakpoint — `max-width: 479px` or `max-height: 479px`), the close button is forced back to the inline placement so it remains usable on small screens.
- Storybook: replaces the single “Show Close” story with “Show Close Inline” and “Show Close Outside” (open by default), and adds a `closePosition` control.

## Usage
```svelte
<!-- Existing behavior (default) -->
<Dialog showClose bind:isOpen>...</Dialog>

<!-- Explicit inline -->
<Dialog showClose closePosition="inline" bind:isOpen>...</Dialog>

<!-- Close outside the dialog (falls back to inline on compact viewports) -->
<Dialog showClose closePosition="outside" bind:isOpen>...</Dialog>
```

## Test plan
- [ ] Storybook → Dialog → **Show Close Inline**: close appears in the header; closing via the button works
- [ ] Storybook → Dialog → **Show Close Outside**: close sits above the top-right corner with an 8px gap; icon uses `color-icon-default`
- [ ] Outside variant: dialog corners still follow `--leo-dialog-border-radius` / `--leo-radius-xl`
- [ ] Outside variant: escape, backdrop click, and the close button all dismiss the dialog
- [ ] Outside variant on a compact viewport (< 480px wide or tall): close moves inside the dialog (inline)
- [ ] Resizing across the 480px breakpoint toggles outside ↔ inline without reopening the dialog
- [ ] `showClose` without `closePosition` still renders the inline close (backwards compatible)
- [ ] Inner Scroll story still shows the inline close correctly while scrolling

## Screens

<img width="1182" height="916" alt="image" src="https://github.com/user-attachments/assets/4a733ccb-c132-4bd5-b40e-2254cf01a748" />

<img width="1184" height="1195" alt="image" src="https://github.com/user-attachments/assets/1c8b88a8-13b4-439b-bc40-79ca98408624" />

## Responsive fallback - Move it inside the dialog when screen is small

<img width="1231" height="960" alt="image" src="https://github.com/user-attachments/assets/abae167b-0af8-4c53-bbbe-8d90e2670dab" />
