### PR TITLE
fix: ensure pnpm is on PATH for socket fix subprocess

### DIFF
--- a/.github/workflows/socket-fix.yml
+++ b/.github/workflows/socket-fix.yml
@@ -39,6 +39,7 @@ jobs:
           SOCKET_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CI: 'true'
         run: |
+          export PATH="${PNPM_HOME}/bin:${PNPM_HOME}:$PATH"
           if ! [[ "$GHSA_IDS" =~ ^GHSA-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}(,[[:space:]]?GHSA-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4})*$ ]]; then
             echo "::error::GHSA_IDS contains invalid entries. Expected format: GHSA-xxxx-xxxx-xxxx (comma or comma-space separated)"
             exit 1

--- a/.github/workflows/socket-fix.yml
+++ b/.github/workflows/socket-fix.yml
@@ -19,12 +19,18 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
         with:
-          node-version: '24.11.1'
+          run_install: false
+
+      - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
+        with:
+          node-version-file: '.node-version'
+          cache: 'pnpm'
+          cache-dependency-path: '**/pnpm-lock.yaml'
 
       - name: Install Socket CLI
-        run: npm install -g @socketsecurity/cli
+        run: pnpm add -g @socketsecurity/cli@1.1.154
 
       - name: Run Socket Fix
         env:


### PR DESCRIPTION
The `socket fix` command spawns pnpm as a subprocess, but on the GitHub runner pnpm's bin directory (set via `PNPM_HOME` by `pnpm/action-setup`) is not always propagated to socket's child process. This causes:

```
✖ Socket unable to locate pnpm; ensure it is available in the PATH environment variable
```

Explicitly export `PNPM_HOME/bin` and `PNPM_HOME` onto `PATH` at the start of the Run Socket Fix step so socket's spawned pnpm subprocess can locate it.