### PR TITLE
fix(socket-fix): author PR commits as brave-support-admin

### DIFF
--- a/.github/workflows/socket-fix.yml
+++ b/.github/workflows/socket-fix.yml
@@ -35,11 +35,19 @@ jobs:
           export PATH="${PNPM_HOME}/bin:$PATH"
           pnpm add -g @socketsecurity/cli@1.1.102
 
+      - name: Configure GPG
+        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6.3.0
+        with:
+          gpg_private_key: ${{ secrets.BRAVE_SUPPORT_ADMIN_COMMIT_SIGNING_KEY }}
+          passphrase: ${{ secrets.BRAVE_SUPPORT_ADMIN_COMMIT_SIGNING_KEY_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
       - name: Run Socket Fix
         env:
           GHSA_IDS: ${{ inputs.ghsa_ids }}
           SOCKET_SECURITY_API_KEY: ${{ secrets.SOCKET_SECURITY_API_KEY }}
-          SOCKET_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SOCKET_CLI_GITHUB_TOKEN: ${{ secrets.LEO_UPDATE_ICONS_PAT }}
           CI: 'true'
         run: |
           export PATH="${PNPM_HOME}/bin:${PNPM_HOME}:$PATH"
@@ -51,14 +59,6 @@ jobs:
           for id in "${IDS[@]}"; do FLAGS+=(--id "${id// /}"); done
           socket config set defaultOrg "brave"
           socket fix . "${FLAGS[@]}"
-
-      - name: Configure GPG
-        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6.3.0
-        with:
-          gpg_private_key: ${{ secrets.BRAVE_SUPPORT_ADMIN_COMMIT_SIGNING_KEY }}
-          passphrase: ${{ secrets.BRAVE_SUPPORT_ADMIN_COMMIT_SIGNING_KEY_PASSPHRASE }}
-          git_user_signingkey: true
-          git_commit_gpgsign: true
 
       - name: Compute branch name
         id: branch


### PR DESCRIPTION
## Problem

PR #1447 (generated by the `socket-fix` workflow) was authored by `github-actions[bot]` instead of `brave-support-admin`, while PR #1434 (generated by `update-icons`) is correctly authored by `brave-support-admin`. Both workflows use the same `peter-evans/create-pull-request` config (`author`, `committer`, `token`), so that isn't the difference.

## Root cause

`socket fix .` (with `CI: 'true'`) creates its **own git commit** using `SOCKET_CLI_GITHUB_TOKEN` before `peter-evans/create-pull-request` runs. The workflow was setting that to the default `GITHUB_TOKEN`, so GitHub attributes the commit to `github-actions[bot]`.

Evidence:
- PR #1447's head commit message is the Socket CLI's format (`fix: GHSA-… - <title>`), not the `commit-message: 'fix: address security advisories'` that `create-pull-request` would have written.
- The run log for `create-pull-request` shows `Configured git author as 'brave-support-admin <…>'` — but by then there were no uncommitted changes left to wrap in a new commit, so the PR inherited Socket's `github-actions[bot]` author.

`update-icons` doesn't hit this because nothing commits before `create-pull-request` runs.

## Fix

1. `SOCKET_CLI_GITHUB_TOKEN: ${{ secrets.LEO_UPDATE_ICONS_PAT }}` — same PAT `update-icons.yml` uses, so Socket's commit is authored by `brave-support-admin`.
2. Move the `Configure GPG` step **before** `Run Socket Fix` so `git config commit.gpgsign=true` is set when Socket makes its commit, making it GPG-verified.

## Verification

Next time the workflow is dispatched, the resulting PR's head commit should be authored by `brave-support-admin` and show as Verified.