### PR TITLE
fix(socket-fix): disable Socket CLI CI mode to prevent auto-PR

### DIFF
--- a/.github/workflows/socket-fix.yml
+++ b/.github/workflows/socket-fix.yml
@@ -60,23 +60,3 @@ jobs:
           for id in "${IDS[@]}"; do FLAGS+=(--id "${id// /}"); done
           socket config set defaultOrg "brave"
           socket fix . "${FLAGS[@]}"
-
-      - name: Compute branch name
-        id: branch
-        env:
-          GHSA_IDS: ${{ inputs.ghsa_ids }}
-        run: |
-          echo "name=socket-fix/$(echo "$GHSA_IDS" | tr ', ' '-' | tr -s '-' | cut -c1-60)" >> "$GITHUB_OUTPUT"
-
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@84ae59a2cdc2258d6fa0732dd66352dddae2a412 # v7.0.9
-        with:
-          commit-message: 'fix: address security advisories'
-          author: brave-support-admin <138038132+brave-support-admin@users.noreply.github.com>
-          committer: brave-support-admin <138038132+brave-support-admin@users.noreply.github.com>
-          branch: ${{ steps.branch.outputs.name }}
-          delete-branch: true
-          base: main
-          title: 'fix: address security advisories'
-          body: 'Addresses: ${{ inputs.ghsa_ids }}'
-          token: ${{ secrets.LEO_UPDATE_ICONS_PAT }}

--- a/.github/workflows/socket-fix.yml
+++ b/.github/workflows/socket-fix.yml
@@ -48,7 +48,8 @@ jobs:
           GHSA_IDS: ${{ inputs.ghsa_ids }}
           SOCKET_SECURITY_API_KEY: ${{ secrets.SOCKET_SECURITY_API_KEY }}
           SOCKET_CLI_GITHUB_TOKEN: ${{ secrets.LEO_UPDATE_ICONS_PAT }}
-          CI: ''
+          SOCKET_CLI_GIT_USER_NAME: brave-support-admin
+          SOCKET_CLI_GIT_USER_EMAIL: 138038132+brave-support-admin@users.noreply.github.com
         run: |
           export PATH="${PNPM_HOME}/bin:${PNPM_HOME}:$PATH"
           if ! [[ "$GHSA_IDS" =~ ^GHSA-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}(,[[:space:]]?GHSA-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4})*$ ]]; then

--- a/.github/workflows/socket-fix.yml
+++ b/.github/workflows/socket-fix.yml
@@ -48,7 +48,7 @@ jobs:
           GHSA_IDS: ${{ inputs.ghsa_ids }}
           SOCKET_SECURITY_API_KEY: ${{ secrets.SOCKET_SECURITY_API_KEY }}
           SOCKET_CLI_GITHUB_TOKEN: ${{ secrets.LEO_UPDATE_ICONS_PAT }}
-          CI: 'true'
+          CI: ''
         run: |
           export PATH="${PNPM_HOME}/bin:${PNPM_HOME}:$PATH"
           if ! [[ "$GHSA_IDS" =~ ^GHSA-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}(,[[:space:]]?GHSA-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4})*$ ]]; then


### PR DESCRIPTION
## Problem

PR #1451's commit is signed but shows as **unverified** (), even though the GPG key is confirmed added to the brave-support-admin account.

## Root cause

With `CI: 'true'`, `socket fix` doesn't just edit files — it commits, pushes, and opens the PR itself. The run log for PR #1451 shows:

```
Run Socket Fix  ✔ Opened PR #1451 for GHSA-5p4m-2wfm-xmqj.
```

Socket creates the git commit using its own hardcoded `github-actions[bot]` identity, ignoring the git config set by the Configure GPG step. So:

- **PR author**: `brave-support-admin` (Socket used the PAT to call the GitHub API)
- **Commit author/committer**: `github-actions[bot]` (Socket's own identity)

The commit *is* GPG-signed with brave-support-admin's key (Configure GPG ran first and set `commit.gpgsign=true`), but GitHub looks up the signing key against the **commit author's** account — `github-actions[bot]` — which doesn't have that key registered. Hence `unknown_key`.

The later `peter-evans/create-pull-request` step finds no uncommitted changes left and does nothing.

## Fix

Set `CI: ''` so Socket only edits files locally, leaving the commit to `peter-evans/create-pull-request` — which uses the brave-support-admin author/committer identity that matches the GPG key.

This matches what brave-core's socket-fix workflow already does (`CI: ''`).

## Verification

Next time the workflow is dispatched, the resulting PR's head commit should be authored by `brave-support-admin` and show as Verified.