### PR TITLE
Use token for dialog backdrop background

### DIFF
--- a/src/components/dialog/dialog.svelte
+++ b/src/components/dialog/dialog.svelte
@@ -148,7 +148,7 @@
 
     --backdrop-background: var(
       --leo-dialog-backdrop-background,
-      rgba(0, 0, 0, 0.1)
+      var(--leo-color-dialogs-scrim-background)
     );
     --backdrop-filter: var(--leo-dialog-backdrop-filter);
 


### PR DESCRIPTION
Replace the hardcoded rgba fallback for the dialog backdrop with the CSS token --leo-color-dialogs-scrim-background in src/components/dialog/dialog.svelte. This centralizes the scrim color into design tokens for consistent theming and easier updates across light/dark modes; behavior is unchanged when the token is defined.