### PR TITLE
[Dialog] Stop dialog content from widening the dialog

### DIFF
--- a/src/components/dialog/dialog.stories.svelte
+++ b/src/components/dialog/dialog.stories.svelte
@@ -64,6 +64,10 @@
   let openDialog
   let isOpen = false
   let scrollDialogOpen = false
+  let truncateDialogOpen = false
+
+  const unbreakableText =
+    'A single line of text which cannot wrap, and is far too long to fit inside the dialog'
 
   const scrollParagraph =
     'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ipsum pharetra est et viverra massa enim aliquam. Volutpat tristique id mi blandit interdum elit quam commodo vel. Ac laoreet magna ac sed diam volutpat. Sit mauris, orci diam in habitasse nec dolor odio pharetra.'
@@ -183,6 +187,21 @@
   </Dialog>
 </Story>
 
+<Story name="Truncating Content" let:args>
+  <Button
+    isDisabled={truncateDialogOpen}
+    onClick={() => (truncateDialogOpen = true)}>Show Dialog</Button
+  >
+  <Dialog {...args} showClose bind:isOpen={truncateDialogOpen}>
+    <div slot="title">Truncating content</div>
+    <div slot="subtitle">
+      Content which cannot wrap truncates to the dialog's width instead of
+      widening it
+    </div>
+    <div class="truncate">{unbreakableText}</div>
+  </Dialog>
+</Story>
+
 <style>
   .alert-container {
     margin-top: var(--leo-spacing-xl);
@@ -196,5 +215,11 @@
 
   .scroll-content p {
     margin: 0;
+  }
+
+  .truncate {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 </style>

--- a/src/components/dialog/dialog.svelte
+++ b/src/components/dialog/dialog.svelte
@@ -156,6 +156,15 @@
     margin: auto;
     border: none;
     display: grid;
+    /* The dialog sets its own width below, so content must never widen it. An
+     * implicit `auto` column can't be narrower than its items' min-content
+     * width, so unbreakable content (`white-space: nowrap` with
+     * `text-overflow: ellipsis`) would push the column past max-width and
+     * scroll the dialog horizontally instead of truncating. `minmax(0, 1fr)`
+     * drops that floor but keeps the growth limit, so an intrinsic
+     * `--leo-dialog-width` (`max-content`, `fit-content`) still hugs its
+     * content. */
+    grid-template-columns: minmax(0, 1fr);
     align-content: start;
 
     width: calc(100% - var(--leo-spacing-m) * 2);


### PR DESCRIPTION
`.leo-dialog` is `display: grid` but never set `grid-template-columns`, so content sat in an implicit `auto` column. An `auto` track can't be narrower than its items' min-content width, so content that can't break. For example, a `white-space: nowrap` + `text-overflow: ellipsis` title, grew the column past the dialog's own `max-width`. The dialog then scrolled horizontally (the top-layer UA style sets `overflow: auto`) and the content never truncated, because the row it lived in had become wider than the dialog. `min-width: 0` on the consumer's flex item doesn't help: it removes the floor on the item's used size, it doesn't cap what the item contributes to an ancestor's intrinsic width.

`grid-template-columns: minmax(0, 1fr)` drops the min-content floor but keeps the growth limit, so a definite-width dialog lays its content out at the declared width, while a dialog given an intrinsic `--leo-dialog-width` (`max-content`, `fit-content`) still hugs its content. Content that genuinely doesn't fit now overflows and scrolls at the dialog's declared width, rather than silently pushing the dialog past its `max-width`.

Adds a Truncating Content story: rows pairing unbreakable text with fixed-size actions, which is the case that used to blow the dialog out.

### Before
<img width="1236" height="1004" alt="image" src="https://github.com/user-attachments/assets/e0f7f529-6ba5-484c-949c-da7c256b4791" />

<img width="1234" height="574" alt="image" src="https://github.com/user-attachments/assets/c5a6ebcd-3e62-4be6-b420-bfd4205d247a" />

### After
<img width="609" height="480" alt="image" src="https://github.com/user-attachments/assets/51949052-6b65-47fc-a3ab-f26c252c8a00" />

<img width="595" height="274" alt="image" src="https://github.com/user-attachments/assets/6fa76cf8-2b16-45d1-b29e-dc43ce21cb0d" />

